### PR TITLE
Adapter-driven status — replace hardcoded enum with external system values

### DIFF
--- a/plan/33-adapter-driven-status.md
+++ b/plan/33-adapter-driven-status.md
@@ -6,84 +6,20 @@ adapters:
   github: builtin
 ---
 
-Status must come from adapters, not from a hardcoded four-value enum.
-The current design has two problems:
+Amos is a preprocessor — it returns raw facts from adapters and lets
+the consuming agent (Claude) interpret what they mean. Amos does not
+decide what "done", "ready", or "blocked" means.
 
-1. `ManualStatus` only has `Done` and `InProgress` — but Jira has custom
-   workflows per project/org, GitHub has labels, open/closed, and draft
-   states. The type is too narrow to represent real-world status.
+## What changed
 
-2. Adapter-resolved status is ignored by the DAG. `ResourceFields.status`
-   is returned from `resolve()` but `compute_status()` only reads the
-   `.amos-status` overlay file. The adapter's answer gets thrown away.
-
-## What needs to change
-
-### 1. Replace `ManualStatus` enum with `String`
-
-**File:** `src/status.rs`
-
-`ManualStatus { Done, InProgress }` → status is just a `String`.
-The `.amos-status` file already uses symbols (`[x]` = done, `[~]` = in-progress).
-Change it to store arbitrary strings: `- [closed] node-name`, `- [In Review] node-name`.
-Keep `[x]` and `[~]` as shorthand aliases for backwards compat.
-
-### 2. Replace `ResourceFields.status` type
-
-**File:** `src/adapter.rs`
-
-`status: Option<ManualStatus>` → `status: Option<String>`.
-Adapters return the raw status string from the external system.
-
-### 3. GitHub adapter returns real status strings
-
-**File:** `src/gh_adapter.rs`
-
-`IssueData::to_status()` currently maps `CLOSED → Done`, `OPEN + label:in-progress → InProgress`.
-Instead, return the actual state: `"closed"`, `"open"`, or the label value.
-Let the DAG consumer decide what "done" means — amos shouldn't hardcode
-GitHub's semantics.
-
-### 4. Feed adapter status into DAG
-
-**File:** `src/dag.rs`
-
-`compute_status()` currently only checks `status_overlay` (from `.amos-status`).
-It needs a second status source: adapter-resolved status.
-Priority: `.amos-status` override > adapter-resolved > computed from deps.
-
-`ComputedStatus` enum needs rethinking — it's the output of `compute_status()`
-but the possible values aren't a fixed set anymore. Options:
-- Return `String` directly (simple, adapters set the vocabulary)
-- Return an enum with a `Custom(String)` variant for adapter statuses
-- Keep `Ready` and `Blocked` as computed states, but `Done`/`InProgress`
-  become adapter-provided strings
-
-The readiness logic (`Ready` vs `Blocked`) is still internal to amos —
-it depends on whether upstream deps are "done". But what counts as "done"
-needs to be configurable per adapter or per project. A GitHub `closed`
-issue is done. A Jira ticket in `Deployed` is done. This mapping belongs
-in the node's frontmatter or adapter config, not in Rust code.
-
-### 5. External adapter protocol
-
-**File:** `src/external_adapter.rs`
-
-External adapters return JSON from `resolve()`. The `status` field in
-that JSON should be passed through as-is (it's already a string in JSON).
-Currently it gets mapped through `ManualStatus` — remove that mapping.
-
-### 6. Output formatting
-
-**File:** `src/output.rs`
-
-`format_dag()` calls `compute_status()` and formats as `[done]`, `[ready]`, etc.
-With string-based status, it should display whatever the adapter returned:
-`[closed]`, `[In Review]`, `[Deployed]`, `[ready]`, `[blocked]`.
-
-## What stays the same
-
-- `.amos-status` file still works as a manual override
-- `Ready` and `Blocked` are still computed by the DAG (not from adapters)
-- The adapter trait interface stays the same shape
-- Dependency edges and DAG structure unchanged
+- `ManualStatus` enum removed entirely
+- `ComputedStatus` enum removed entirely — no `is_done()`, no `is_actionable()`
+- `ResourceFields.status` replaced with `facts: HashMap<String, String>` —
+  adapters return whatever key-value facts they have (state, labels, etc.)
+- GitHub adapter returns raw facts: `{"state": "CLOSED", "labels": "bug, priority-high"}`
+- External adapters pass through all JSON fields as facts
+- `.amos-status` stores raw strings: `[x]`→"done", `[~]`→"in-progress",
+  `[closed]`→"closed", `[In Review]`→"In Review"
+- Output shows raw overlay status without interpretation — no `[ready]`/`[blocked]`
+- Prune only removes nodes explicitly marked `[x]` (done) in `.amos-status`
+- The DAG is a pure data structure: graph + overlay. No status computation.

--- a/plan/33-adapter-driven-status.md
+++ b/plan/33-adapter-driven-status.md
@@ -1,0 +1,89 @@
+---
+whoami: amos
+name: "@github:tatolab/amos#33"
+description: Adapter-driven status — statuses come from external systems, not hardcoded enums
+adapters:
+  github: builtin
+---
+
+Status must come from adapters, not from a hardcoded four-value enum.
+The current design has two problems:
+
+1. `ManualStatus` only has `Done` and `InProgress` — but Jira has custom
+   workflows per project/org, GitHub has labels, open/closed, and draft
+   states. The type is too narrow to represent real-world status.
+
+2. Adapter-resolved status is ignored by the DAG. `ResourceFields.status`
+   is returned from `resolve()` but `compute_status()` only reads the
+   `.amos-status` overlay file. The adapter's answer gets thrown away.
+
+## What needs to change
+
+### 1. Replace `ManualStatus` enum with `String`
+
+**File:** `src/status.rs`
+
+`ManualStatus { Done, InProgress }` → status is just a `String`.
+The `.amos-status` file already uses symbols (`[x]` = done, `[~]` = in-progress).
+Change it to store arbitrary strings: `- [closed] node-name`, `- [In Review] node-name`.
+Keep `[x]` and `[~]` as shorthand aliases for backwards compat.
+
+### 2. Replace `ResourceFields.status` type
+
+**File:** `src/adapter.rs`
+
+`status: Option<ManualStatus>` → `status: Option<String>`.
+Adapters return the raw status string from the external system.
+
+### 3. GitHub adapter returns real status strings
+
+**File:** `src/gh_adapter.rs`
+
+`IssueData::to_status()` currently maps `CLOSED → Done`, `OPEN + label:in-progress → InProgress`.
+Instead, return the actual state: `"closed"`, `"open"`, or the label value.
+Let the DAG consumer decide what "done" means — amos shouldn't hardcode
+GitHub's semantics.
+
+### 4. Feed adapter status into DAG
+
+**File:** `src/dag.rs`
+
+`compute_status()` currently only checks `status_overlay` (from `.amos-status`).
+It needs a second status source: adapter-resolved status.
+Priority: `.amos-status` override > adapter-resolved > computed from deps.
+
+`ComputedStatus` enum needs rethinking — it's the output of `compute_status()`
+but the possible values aren't a fixed set anymore. Options:
+- Return `String` directly (simple, adapters set the vocabulary)
+- Return an enum with a `Custom(String)` variant for adapter statuses
+- Keep `Ready` and `Blocked` as computed states, but `Done`/`InProgress`
+  become adapter-provided strings
+
+The readiness logic (`Ready` vs `Blocked`) is still internal to amos —
+it depends on whether upstream deps are "done". But what counts as "done"
+needs to be configurable per adapter or per project. A GitHub `closed`
+issue is done. A Jira ticket in `Deployed` is done. This mapping belongs
+in the node's frontmatter or adapter config, not in Rust code.
+
+### 5. External adapter protocol
+
+**File:** `src/external_adapter.rs`
+
+External adapters return JSON from `resolve()`. The `status` field in
+that JSON should be passed through as-is (it's already a string in JSON).
+Currently it gets mapped through `ManualStatus` — remove that mapping.
+
+### 6. Output formatting
+
+**File:** `src/output.rs`
+
+`format_dag()` calls `compute_status()` and formats as `[done]`, `[ready]`, etc.
+With string-based status, it should display whatever the adapter returned:
+`[closed]`, `[In Review]`, `[Deployed]`, `[ready]`, `[blocked]`.
+
+## What stays the same
+
+- `.amos-status` file still works as a manual override
+- `Ready` and `Blocked` are still computed by the DAG (not from adapters)
+- The adapter trait interface stays the same shape
+- Dependency edges and DAG structure unchanged

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1,15 +1,13 @@
 use anyhow::Result;
 use std::collections::HashMap;
 
-use crate::status::ManualStatus;
-
 /// Resolved fields from an adapter. Each field is optional —
 /// the adapter returns whatever it can resolve for the given URI.
 #[derive(Debug, Default, Clone)]
 pub struct ResourceFields {
     pub name: Option<String>,
     pub description: Option<String>,
-    pub status: Option<ManualStatus>,
+    pub status: Option<String>,
     pub body: Option<String>,
 }
 
@@ -153,7 +151,7 @@ mod tests {
             Ok(ResourceFields {
                 name: Some(format!("Mock: {}", reference)),
                 description: Some("Resolved by mock adapter".to_string()),
-                status: Some(ManualStatus::Done),
+                status: Some("done".to_string()),
                 body: None,
             })
         }
@@ -172,7 +170,7 @@ mod tests {
 
         let fields = registry.resolve("@mock:issue-42").unwrap().unwrap();
         assert_eq!(fields.name.as_deref(), Some("Mock: issue-42"));
-        assert_eq!(fields.status, Some(ManualStatus::Done));
+        assert_eq!(fields.status.as_deref(), Some("done"));
     }
 
     #[test]

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -7,8 +7,12 @@ use std::collections::HashMap;
 pub struct ResourceFields {
     pub name: Option<String>,
     pub description: Option<String>,
-    pub status: Option<String>,
     pub body: Option<String>,
+    /// Raw facts from the external system. The adapter decides what to include.
+    /// Amos passes these through without interpretation — the consuming agent
+    /// reads the facts and reasons about them.
+    /// Examples: {"state": "CLOSED", "labels": "bug, priority-high"}
+    pub facts: HashMap<String, String>,
 }
 
 /// Adapter trait — resolves URIs within a registered scheme.
@@ -151,8 +155,8 @@ mod tests {
             Ok(ResourceFields {
                 name: Some(format!("Mock: {}", reference)),
                 description: Some("Resolved by mock adapter".to_string()),
-                status: Some("done".to_string()),
                 body: None,
+                facts: HashMap::from([("state".to_string(), "closed".to_string())]),
             })
         }
     }
@@ -170,7 +174,7 @@ mod tests {
 
         let fields = registry.resolve("@mock:issue-42").unwrap().unwrap();
         assert_eq!(fields.name.as_deref(), Some("Mock: issue-42"));
-        assert_eq!(fields.status.as_deref(), Some("done"));
+        assert_eq!(fields.facts.get("state").map(|s| s.as_str()), Some("closed"));
     }
 
     #[test]

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -7,65 +7,12 @@ use std::collections::HashMap;
 
 use crate::parser::Node;
 
-/// Computed status of a node in the DAG.
-///
-/// `Ready` and `Blocked` are computed by the DAG from dependency edges.
-/// `External` carries the raw status string from an adapter or the
-/// `.amos-status` overlay — adapters define their own vocabulary
-/// (e.g. "closed", "In Review", "Deployed").
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ComputedStatus {
-    Ready,
-    Blocked,
-    External(String),
-}
-
-impl ComputedStatus {
-    /// Whether this status is considered "done" for dependency resolution.
-    pub fn is_done(&self) -> bool {
-        match self {
-            ComputedStatus::External(s) => is_done_status(s),
-            _ => false,
-        }
-    }
-
-    /// Whether this node is actionable (ready or actively being worked on).
-    pub fn is_actionable(&self) -> bool {
-        match self {
-            ComputedStatus::Ready => true,
-            ComputedStatus::External(s) => is_active_status(s),
-            _ => false,
-        }
-    }
-}
-
-/// Known terminal status strings that count as "done" for dependency edges.
-fn is_done_status(s: &str) -> bool {
-    matches!(
-        s.to_lowercase().as_str(),
-        "done" | "closed" | "resolved" | "completed" | "merged"
-    )
-}
-
-/// Known active status strings (work in progress, not done).
-fn is_active_status(s: &str) -> bool {
-    matches!(
-        s.to_lowercase().as_str(),
-        "in-progress" | "in progress" | "active" | "wip"
-    )
-}
-
-impl std::fmt::Display for ComputedStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ComputedStatus::Ready => write!(f, "ready"),
-            ComputedStatus::Blocked => write!(f, "blocked"),
-            ComputedStatus::External(s) => write!(f, "{}", s),
-        }
-    }
-}
-
 /// The dependency DAG built from parsed nodes.
+///
+/// The DAG is a pure data structure — it stores the graph and an overlay
+/// of status strings from `.amos-status`. It does not interpret what any
+/// status value means. The consuming agent reads the raw facts and reasons
+/// about readiness, completion, and priority.
 pub struct Dag {
     pub graph: DiGraph<Node, ()>,
     pub name_to_index: HashMap<String, NodeIndex>,
@@ -187,81 +134,10 @@ impl Dag {
             .map(|&idx| &self.graph[idx])
     }
 
-    /// Compute the status of a single node.
-    pub fn compute_status(&self, name: &str) -> Option<ComputedStatus> {
-        let &idx = self.name_to_index.get(name)?;
-        let mut visited = std::collections::HashSet::new();
-        Some(self.compute_status_for_index(idx, &mut visited))
-    }
-
-    fn compute_status_for_index(
-        &self,
-        idx: NodeIndex,
-        visited: &mut std::collections::HashSet<NodeIndex>,
-    ) -> ComputedStatus {
-        if !visited.insert(idx) {
-            // Cycle — can never resolve to done
-            return ComputedStatus::Blocked;
-        }
-
-        let node = &self.graph[idx];
-
-        // Check status overlay (from .amos-status or adapter sync)
-        if let Some(status) = self.status_overlay.get(&node.name) {
-            return ComputedStatus::External(status.clone());
-        }
-
-        // Check upstream deps — all must be done for this node to be ready
-        let all_upstream_done = self
-            .graph
-            .edges_directed(idx, Direction::Incoming)
-            .all(|edge| {
-                let upstream_idx = edge.source();
-                self.compute_status_for_index(upstream_idx, visited).is_done()
-            });
-
-        if all_upstream_done {
-            ComputedStatus::Ready
-        } else {
-            ComputedStatus::Blocked
-        }
-    }
-
-    /// Find all nodes with status Ready.
-    pub fn find_ready(&self) -> Vec<&Node> {
-        self.graph
-            .node_indices()
-            .filter(|&idx| {
-                let mut visited = std::collections::HashSet::new();
-                self.compute_status_for_index(idx, &mut visited) == ComputedStatus::Ready
-            })
-            .map(|idx| &self.graph[idx])
-            .collect()
-    }
-
-    /// Find all blocked nodes with the names of what blocks them.
-    pub fn find_blocked_with_blockers(&self) -> Vec<(&Node, Vec<String>)> {
-        self.graph
-            .node_indices()
-            .filter(|&idx| {
-                let mut visited = std::collections::HashSet::new();
-                self.compute_status_for_index(idx, &mut visited) == ComputedStatus::Blocked
-            })
-            .map(|idx| {
-                let blockers: Vec<String> = self
-                    .graph
-                    .edges_directed(idx, Direction::Incoming)
-                    .filter(|edge| {
-                        let mut visited = std::collections::HashSet::new();
-                        !self
-                            .compute_status_for_index(edge.source(), &mut visited)
-                            .is_done()
-                    })
-                    .map(|edge| self.graph[edge.source()].name.clone())
-                    .collect();
-                (&self.graph[idx], blockers)
-            })
-            .collect()
+    /// Get the raw overlay status for a node (from .amos-status).
+    /// Returns the status string as-is — no interpretation.
+    pub fn get_overlay_status(&self, name: &str) -> Option<&str> {
+        self.status_overlay.get(name).map(|s| s.as_str())
     }
 
     /// Find shortest path between two nodes (BFS).
@@ -477,96 +353,42 @@ mod tests {
     }
 
     #[test]
-    fn test_simple_chain_status() {
-        // A -> B -> C, A is done
-        let nodes = vec![
-            make_node("a", vec![], vec!["b"]),
-            make_node("b", vec!["a"], vec!["c"]),
-            make_node("c", vec!["b"], vec![]),
-        ];
-        let dag = Dag::build(nodes).unwrap();
-        let dag = with_status(dag, vec![("a", "done")]);
-
-        assert!(dag.compute_status("a").unwrap().is_done());
-        assert_eq!(dag.compute_status("b"), Some(ComputedStatus::Ready));
-        assert_eq!(dag.compute_status("c"), Some(ComputedStatus::Blocked));
-    }
-
-    #[test]
-    fn test_no_deps_is_ready() {
-        let nodes = vec![make_node("a", vec![], vec![])];
-        let dag = Dag::build(nodes).unwrap();
-        assert_eq!(dag.compute_status("a"), Some(ComputedStatus::Ready));
-    }
-
-    #[test]
-    fn test_in_progress_status() {
-        let nodes = vec![make_node("a", vec![], vec![])];
-        let dag = Dag::build(nodes).unwrap();
-        let dag = with_status(dag, vec![("a", "in-progress")]);
-        assert_eq!(
-            dag.compute_status("a"),
-            Some(ComputedStatus::External("in-progress".to_string()))
-        );
-    }
-
-    #[test]
-    fn test_find_ready() {
-        let nodes = vec![
-            make_node("a", vec![], vec!["b"]),
-            make_node("b", vec!["a"], vec!["c"]),
-            make_node("c", vec!["b"], vec![]),
-        ];
-        let dag = Dag::build(nodes).unwrap();
-        let dag = with_status(dag, vec![("a", "done")]);
-        let ready: Vec<&str> = dag.find_ready().iter().map(|n| n.name.as_str()).collect();
-        assert_eq!(ready, vec!["b"]);
-    }
-
-    #[test]
-    fn test_closed_is_done_for_deps() {
-        // GitHub "closed" should unblock downstream
+    fn test_overlay_status() {
         let nodes = vec![
             make_node("a", vec![], vec!["b"]),
             make_node("b", vec!["a"], vec![]),
         ];
         let dag = Dag::build(nodes).unwrap();
-        let dag = with_status(dag, vec![("a", "closed")]);
+        let dag = with_status(dag, vec![("a", "done")]);
 
-        assert!(dag.compute_status("a").unwrap().is_done());
-        assert_eq!(dag.compute_status("b"), Some(ComputedStatus::Ready));
+        assert_eq!(dag.get_overlay_status("a"), Some("done"));
+        assert_eq!(dag.get_overlay_status("b"), None);
     }
 
     #[test]
-    fn test_arbitrary_status_not_done() {
-        // A non-terminal status should not unblock downstream
-        let nodes = vec![
-            make_node("a", vec![], vec!["b"]),
-            make_node("b", vec!["a"], vec![]),
-        ];
+    fn test_overlay_preserves_raw_strings() {
+        let nodes = vec![make_node("a", vec![], vec![])];
         let dag = Dag::build(nodes).unwrap();
         let dag = with_status(dag, vec![("a", "In Review")]);
 
-        assert!(!dag.compute_status("a").unwrap().is_done());
-        assert_eq!(dag.compute_status("b"), Some(ComputedStatus::Blocked));
+        // Amos stores the string as-is — no interpretation
+        assert_eq!(dag.get_overlay_status("a"), Some("In Review"));
     }
 
     #[test]
-    fn test_blocked_with_blockers() {
+    fn test_graph_structure() {
         let nodes = vec![
-            make_node("a", vec![], vec!["c"]),
-            make_node("b", vec![], vec!["c"]),
-            make_node("c", vec!["a", "b"], vec![]),
+            make_node("a", vec![], vec!["b"]),
+            make_node("b", vec!["a"], vec!["c"]),
+            make_node("c", vec!["b"], vec![]),
         ];
         let dag = Dag::build(nodes).unwrap();
-        // a and b are ready (no upstream), c is blocked by a and b
-        // But a and b are "ready" not "done", so c is blocked
-        let blocked = dag.find_blocked_with_blockers();
-        assert_eq!(blocked.len(), 1);
-        assert_eq!(blocked[0].0.name, "c");
-        let mut blockers = blocked[0].1.clone();
-        blockers.sort();
-        assert_eq!(blockers, vec!["a", "b"]);
+
+        assert!(dag.upstream_of("a").is_empty());
+        assert_eq!(dag.upstream_of("b").len(), 1);
+        assert_eq!(dag.upstream_of("b")[0].name, "a");
+        assert_eq!(dag.downstream_of("a").len(), 1);
+        assert_eq!(dag.downstream_of("a")[0].name, "b");
     }
 
     #[test]

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -6,24 +6,61 @@ use petgraph::Direction;
 use std::collections::HashMap;
 
 use crate::parser::Node;
-use crate::status::ManualStatus;
 
 /// Computed status of a node in the DAG.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// `Ready` and `Blocked` are computed by the DAG from dependency edges.
+/// `External` carries the raw status string from an adapter or the
+/// `.amos-status` overlay — adapters define their own vocabulary
+/// (e.g. "closed", "In Review", "Deployed").
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ComputedStatus {
-    Done,
-    InProgress,
     Ready,
     Blocked,
+    External(String),
+}
+
+impl ComputedStatus {
+    /// Whether this status is considered "done" for dependency resolution.
+    pub fn is_done(&self) -> bool {
+        match self {
+            ComputedStatus::External(s) => is_done_status(s),
+            _ => false,
+        }
+    }
+
+    /// Whether this node is actionable (ready or actively being worked on).
+    pub fn is_actionable(&self) -> bool {
+        match self {
+            ComputedStatus::Ready => true,
+            ComputedStatus::External(s) => is_active_status(s),
+            _ => false,
+        }
+    }
+}
+
+/// Known terminal status strings that count as "done" for dependency edges.
+fn is_done_status(s: &str) -> bool {
+    matches!(
+        s.to_lowercase().as_str(),
+        "done" | "closed" | "resolved" | "completed" | "merged"
+    )
+}
+
+/// Known active status strings (work in progress, not done).
+fn is_active_status(s: &str) -> bool {
+    matches!(
+        s.to_lowercase().as_str(),
+        "in-progress" | "in progress" | "active" | "wip"
+    )
 }
 
 impl std::fmt::Display for ComputedStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ComputedStatus::Done => write!(f, "done"),
-            ComputedStatus::InProgress => write!(f, "in-progress"),
             ComputedStatus::Ready => write!(f, "ready"),
             ComputedStatus::Blocked => write!(f, "blocked"),
+            ComputedStatus::External(s) => write!(f, "{}", s),
         }
     }
 }
@@ -32,7 +69,7 @@ impl std::fmt::Display for ComputedStatus {
 pub struct Dag {
     pub graph: DiGraph<Node, ()>,
     pub name_to_index: HashMap<String, NodeIndex>,
-    status_overlay: HashMap<String, ManualStatus>,
+    status_overlay: HashMap<String, String>,
 }
 
 /// A validation issue found during DAG check.
@@ -82,8 +119,8 @@ impl std::fmt::Display for DagIssue {
 }
 
 impl Dag {
-    /// Apply external status overlay (from .amos-status file).
-    pub fn apply_status_overlay(&mut self, statuses: HashMap<String, ManualStatus>) {
+    /// Apply external status overlay (from .amos-status file or adapters).
+    pub fn apply_status_overlay(&mut self, statuses: HashMap<String, String>) {
         self.status_overlay = statuses;
     }
 
@@ -169,21 +206,18 @@ impl Dag {
 
         let node = &self.graph[idx];
 
-        // Check status overlay
-        if let Some(&status) = self.status_overlay.get(&node.name) {
-            match status {
-                ManualStatus::Done => return ComputedStatus::Done,
-                ManualStatus::InProgress => return ComputedStatus::InProgress,
-            }
+        // Check status overlay (from .amos-status or adapter sync)
+        if let Some(status) = self.status_overlay.get(&node.name) {
+            return ComputedStatus::External(status.clone());
         }
 
-        // Rule 3 & 4: check upstream deps
+        // Check upstream deps — all must be done for this node to be ready
         let all_upstream_done = self
             .graph
             .edges_directed(idx, Direction::Incoming)
             .all(|edge| {
                 let upstream_idx = edge.source();
-                self.compute_status_for_index(upstream_idx, visited) == ComputedStatus::Done
+                self.compute_status_for_index(upstream_idx, visited).is_done()
             });
 
         if all_upstream_done {
@@ -219,8 +253,9 @@ impl Dag {
                     .edges_directed(idx, Direction::Incoming)
                     .filter(|edge| {
                         let mut visited = std::collections::HashSet::new();
-                        self.compute_status_for_index(edge.source(), &mut visited)
-                            != ComputedStatus::Done
+                        !self
+                            .compute_status_for_index(edge.source(), &mut visited)
+                            .is_done()
                     })
                     .map(|edge| self.graph[edge.source()].name.clone())
                     .collect();
@@ -432,10 +467,10 @@ mod tests {
         }
     }
 
-    fn with_status(mut dag: Dag, statuses: Vec<(&str, ManualStatus)>) -> Dag {
-        let map: HashMap<String, ManualStatus> = statuses
+    fn with_status(mut dag: Dag, statuses: Vec<(&str, &str)>) -> Dag {
+        let map: HashMap<String, String> = statuses
             .into_iter()
-            .map(|(n, s)| (n.to_string(), s))
+            .map(|(n, s)| (n.to_string(), s.to_string()))
             .collect();
         dag.apply_status_overlay(map);
         dag
@@ -450,9 +485,9 @@ mod tests {
             make_node("c", vec!["b"], vec![]),
         ];
         let dag = Dag::build(nodes).unwrap();
-        let dag = with_status(dag, vec![("a", ManualStatus::Done)]);
+        let dag = with_status(dag, vec![("a", "done")]);
 
-        assert_eq!(dag.compute_status("a"), Some(ComputedStatus::Done));
+        assert!(dag.compute_status("a").unwrap().is_done());
         assert_eq!(dag.compute_status("b"), Some(ComputedStatus::Ready));
         assert_eq!(dag.compute_status("c"), Some(ComputedStatus::Blocked));
     }
@@ -468,8 +503,11 @@ mod tests {
     fn test_in_progress_status() {
         let nodes = vec![make_node("a", vec![], vec![])];
         let dag = Dag::build(nodes).unwrap();
-        let dag = with_status(dag, vec![("a", ManualStatus::InProgress)]);
-        assert_eq!(dag.compute_status("a"), Some(ComputedStatus::InProgress));
+        let dag = with_status(dag, vec![("a", "in-progress")]);
+        assert_eq!(
+            dag.compute_status("a"),
+            Some(ComputedStatus::External("in-progress".to_string()))
+        );
     }
 
     #[test]
@@ -480,9 +518,37 @@ mod tests {
             make_node("c", vec!["b"], vec![]),
         ];
         let dag = Dag::build(nodes).unwrap();
-        let dag = with_status(dag, vec![("a", ManualStatus::Done)]);
+        let dag = with_status(dag, vec![("a", "done")]);
         let ready: Vec<&str> = dag.find_ready().iter().map(|n| n.name.as_str()).collect();
         assert_eq!(ready, vec!["b"]);
+    }
+
+    #[test]
+    fn test_closed_is_done_for_deps() {
+        // GitHub "closed" should unblock downstream
+        let nodes = vec![
+            make_node("a", vec![], vec!["b"]),
+            make_node("b", vec!["a"], vec![]),
+        ];
+        let dag = Dag::build(nodes).unwrap();
+        let dag = with_status(dag, vec![("a", "closed")]);
+
+        assert!(dag.compute_status("a").unwrap().is_done());
+        assert_eq!(dag.compute_status("b"), Some(ComputedStatus::Ready));
+    }
+
+    #[test]
+    fn test_arbitrary_status_not_done() {
+        // A non-terminal status should not unblock downstream
+        let nodes = vec![
+            make_node("a", vec![], vec!["b"]),
+            make_node("b", vec!["a"], vec![]),
+        ];
+        let dag = Dag::build(nodes).unwrap();
+        let dag = with_status(dag, vec![("a", "In Review")]);
+
+        assert!(!dag.compute_status("a").unwrap().is_done());
+        assert_eq!(dag.compute_status("b"), Some(ComputedStatus::Blocked));
     }
 
     #[test]

--- a/src/external_adapter.rs
+++ b/src/external_adapter.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use std::process::{Command, Stdio};
 
 use crate::adapter::{Adapter, ResourceFields};
-use crate::status::ManualStatus;
 
 /// External adapter — runs a subprocess that speaks the amos adapter protocol.
 ///
@@ -139,12 +138,8 @@ impl ExternalAdapter {
     }
 }
 
-fn parse_status(value: &serde_json::Value) -> Option<ManualStatus> {
-    match value.as_str() {
-        Some("done") => Some(ManualStatus::Done),
-        Some("in-progress") => Some(ManualStatus::InProgress),
-        _ => None,
-    }
+fn parse_status(value: &serde_json::Value) -> Option<String> {
+    value.as_str().map(String::from)
 }
 
 fn json_to_fields(json: &serde_json::Value) -> ResourceFields {

--- a/src/external_adapter.rs
+++ b/src/external_adapter.rs
@@ -138,16 +138,27 @@ impl ExternalAdapter {
     }
 }
 
-fn parse_status(value: &serde_json::Value) -> Option<String> {
-    value.as_str().map(String::from)
-}
-
 fn json_to_fields(json: &serde_json::Value) -> ResourceFields {
+    // Extract all non-reserved fields as raw facts for the consuming agent
+    let mut facts = HashMap::new();
+    if let Some(obj) = json.as_object() {
+        for (key, value) in obj {
+            if matches!(key.as_str(), "name" | "description" | "body") {
+                continue;
+            }
+            if let Some(s) = value.as_str() {
+                facts.insert(key.clone(), s.to_string());
+            } else if !value.is_null() {
+                facts.insert(key.clone(), value.to_string());
+            }
+        }
+    }
+
     ResourceFields {
         name: json["name"].as_str().map(String::from),
         description: json["description"].as_str().map(String::from),
-        status: parse_status(&json["status"]),
         body: json["body"].as_str().map(String::from),
+        facts,
     }
 }
 

--- a/src/ffmpeg_adapter.rs
+++ b/src/ffmpeg_adapter.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, Context, Result};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -212,7 +213,7 @@ impl Adapter for FfmpegAdapter {
             Ok(ResourceFields {
                 name: None,
                 description: None,
-                status: None,
+                facts: HashMap::new(),
                 body: Some(body),
             })
         } else if is_audio(&full_path) {
@@ -225,7 +226,7 @@ impl Adapter for FfmpegAdapter {
             Ok(ResourceFields {
                 name: None,
                 description: None,
-                status: None,
+                facts: HashMap::new(),
                 body: Some(format!(
                     "**Audio: {}**\n\n![{} waveform]({})\n",
                     reference, filename, waveform.display()

--- a/src/file_adapter.rs
+++ b/src/file_adapter.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, Result};
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::adapter::{Adapter, ResourceFields};
@@ -68,7 +69,7 @@ impl Adapter for FileAdapter {
             Ok(ResourceFields {
                 name: None,
                 description: None,
-                status: None,
+                facts: HashMap::new(),
                 body: Some(format!("```{}\n{}\n```", ext, content)),
             })
         } else if Self::is_image_file(&full_path) {
@@ -81,7 +82,7 @@ impl Adapter for FileAdapter {
             Ok(ResourceFields {
                 name: None,
                 description: None,
-                status: None,
+                facts: HashMap::new(),
                 body: Some(format!("![{}]({})", filename, full_path.display())),
             })
         } else {
@@ -89,7 +90,7 @@ impl Adapter for FileAdapter {
             Ok(ResourceFields {
                 name: None,
                 description: None,
-                status: None,
+                facts: HashMap::new(),
                 body: Some(format!("📎 {}", full_path.display())),
             })
         }

--- a/src/gh_adapter.rs
+++ b/src/gh_adapter.rs
@@ -102,7 +102,7 @@ impl GhAdapter {
             Ok(ResourceFields {
                 name: None,
                 description: None,
-                status: None,
+                facts: HashMap::new(),
                 body: Some(format!("![{}]({})", filename, local_path.display())),
             })
         } else {
@@ -115,7 +115,7 @@ impl GhAdapter {
                 return Ok(ResourceFields {
                     name: None,
                     description: None,
-                    status: None,
+                    facts: HashMap::new(),
                     body: Some(format!(
                         "[GitHub file: {}/{}](https://github.com/{}/blob/HEAD/{})",
                         repo, file_path, repo, file_path
@@ -129,7 +129,7 @@ impl GhAdapter {
             Ok(ResourceFields {
                 name: None,
                 description: None,
-                status: None,
+                facts: HashMap::new(),
                 body: Some(format!("```{}\n{}\n```", ext, content)),
             })
         }
@@ -167,21 +167,14 @@ struct IssueData {
 }
 
 impl IssueData {
-    fn to_status(&self) -> Option<String> {
-        match self.state.as_str() {
-            "CLOSED" => Some("closed".to_string()),
-            "OPEN" => {
-                // Surface status-like labels from the external system
-                for label in &self.labels {
-                    let lower = label.to_lowercase();
-                    if lower == "in-progress" || lower == "in progress" {
-                        return Some(label.clone());
-                    }
-                }
-                None // open with no status label = no explicit status
-            }
-            other => Some(other.to_lowercase()),
+    /// Return raw facts from GitHub — the consuming agent interprets them.
+    fn to_facts(&self) -> HashMap<String, String> {
+        let mut facts = HashMap::new();
+        facts.insert("state".to_string(), self.state.clone());
+        if !self.labels.is_empty() {
+            facts.insert("labels".to_string(), self.labels.join(", "));
         }
+        facts
     }
 }
 
@@ -210,8 +203,8 @@ impl Adapter for GhAdapter {
         Ok(ResourceFields {
             name: Some(issue.title.clone()),
             description: Some(issue.title.clone()),
-            status: issue.to_status(),
             body,
+            facts: issue.to_facts(),
         })
     }
 
@@ -264,12 +257,12 @@ impl Adapter for GhAdapter {
                         ResourceFields {
                             name: Some(issue.title.clone()),
                             description: Some(issue.title.clone()),
-                            status: issue.to_status(),
                             body: if issue.body.is_empty() {
                                 None
                             } else {
                                 Some(issue.body.clone())
                             },
+                            facts: issue.to_facts(),
                         },
                     );
                 }

--- a/src/gh_adapter.rs
+++ b/src/gh_adapter.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use std::process::Command;
 
 use crate::adapter::{Adapter, ResourceFields};
-use crate::status::ManualStatus;
 use crate::url_adapter::download_to_cache;
 
 /// GitHub adapter — resolves `gh:` URIs via the `gh` CLI.
@@ -168,17 +167,20 @@ struct IssueData {
 }
 
 impl IssueData {
-    fn to_status(&self) -> Option<ManualStatus> {
+    fn to_status(&self) -> Option<String> {
         match self.state.as_str() {
-            "CLOSED" => Some(ManualStatus::Done),
+            "CLOSED" => Some("closed".to_string()),
             "OPEN" => {
-                if self.labels.iter().any(|l| l == "in-progress") {
-                    Some(ManualStatus::InProgress)
-                } else {
-                    None
+                // Surface status-like labels from the external system
+                for label in &self.labels {
+                    let lower = label.to_lowercase();
+                    if lower == "in-progress" || lower == "in progress" {
+                        return Some(label.clone());
+                    }
                 }
+                None // open with no status label = no explicit status
             }
-            _ => None,
+            other => Some(other.to_lowercase()),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use amos::url_adapter::UrlAdapter;
 use amos::output;
 use amos::parser;
 use amos::scanner;
-use amos::status::{self, ManualStatus};
+use amos::status;
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -92,13 +92,9 @@ fn main() -> Result<()> {
         let mut synced = 0;
         for (uri, fields) in &results {
             if let Some(s) = &fields.status {
-                status::write_status(&scan_root, uri, *s)
+                status::write_status(&scan_root, uri, s)
                     .with_context(|| format!("writing status for {}", uri))?;
-                let symbol = match s {
-                    ManualStatus::Done => "x",
-                    ManualStatus::InProgress => "~",
-                };
-                eprintln!("[{}] {}", symbol, uri);
+                eprintln!("[{}] {}", s, uri);
                 synced += 1;
             }
         }
@@ -114,19 +110,15 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-use amos::dag::ComputedStatus;
-
 /// Prune done nodes that aren't upstream of any ready/in-progress work.
 fn handle_prune(dag: &Dag, scan_root: &std::path::Path) -> Result<()> {
-    // Find all ready/in-progress nodes
+    // Find all actionable nodes (ready or in-progress)
     let active_nodes: Vec<&str> = dag
         .all_nodes()
         .iter()
         .filter(|n| {
-            matches!(
-                dag.compute_status(&n.name),
-                Some(ComputedStatus::Ready) | Some(ComputedStatus::InProgress)
-            )
+            dag.compute_status(&n.name)
+                .map_or(false, |s| s.is_actionable())
         })
         .map(|n| n.name.as_str())
         .collect();
@@ -138,12 +130,12 @@ fn handle_prune(dag: &Dag, scan_root: &std::path::Path) -> Result<()> {
         collect_upstream(dag, name, &mut needed);
     }
 
-    // Also keep blocked nodes (they have pending work)
+    // Also keep non-done nodes (they have pending work)
     for node in dag.all_nodes() {
-        if matches!(
-            dag.compute_status(&node.name),
-            Some(ComputedStatus::Blocked) | Some(ComputedStatus::InProgress) | Some(ComputedStatus::Ready)
-        ) {
+        if !dag
+            .compute_status(&node.name)
+            .map_or(false, |s| s.is_done())
+        {
             needed.insert(node.name.clone());
         }
     }
@@ -153,7 +145,9 @@ fn handle_prune(dag: &Dag, scan_root: &std::path::Path) -> Result<()> {
     let prunable: Vec<_> = all_nodes
         .iter()
         .filter(|n| {
-            dag.compute_status(&n.name) == Some(ComputedStatus::Done) && !needed.contains(&n.name)
+            dag.compute_status(&n.name)
+                .map_or(false, |s| s.is_done())
+                && !needed.contains(&n.name)
         })
         .collect();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,10 +91,17 @@ fn main() -> Result<()> {
 
         let mut synced = 0;
         for (uri, fields) in &results {
-            if let Some(s) = &fields.status {
-                status::write_status(&scan_root, uri, s)
+            // Write the "state" fact to the overlay if the adapter provided one
+            if let Some(state) = fields.facts.get("state") {
+                status::write_status(&scan_root, uri, state)
                     .with_context(|| format!("writing status for {}", uri))?;
-                eprintln!("[{}] {}", s, uri);
+                // Show all facts the adapter returned
+                let facts_display: Vec<String> = fields
+                    .facts
+                    .iter()
+                    .map(|(k, v)| format!("{}={}", k, v))
+                    .collect();
+                eprintln!("{}: {}", uri, facts_display.join(", "));
                 synced += 1;
             }
         }
@@ -110,44 +117,25 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-/// Prune done nodes that aren't upstream of any ready/in-progress work.
+/// Prune nodes explicitly marked "done" in .amos-status that aren't
+/// needed as upstream context for non-done nodes.
 fn handle_prune(dag: &Dag, scan_root: &std::path::Path) -> Result<()> {
-    // Find all actionable nodes (ready or in-progress)
-    let active_nodes: Vec<&str> = dag
-        .all_nodes()
-        .iter()
-        .filter(|n| {
-            dag.compute_status(&n.name)
-                .map_or(false, |s| s.is_actionable())
-        })
-        .map(|n| n.name.as_str())
-        .collect();
+    let all_nodes = dag.all_nodes();
 
-    // Collect all nodes that are transitively upstream of active nodes
+    // Collect all non-done nodes and everything transitively upstream of them
     let mut needed: HashSet<String> = HashSet::new();
-    for name in &active_nodes {
-        needed.insert(name.to_string());
-        collect_upstream(dag, name, &mut needed);
-    }
-
-    // Also keep non-done nodes (they have pending work)
-    for node in dag.all_nodes() {
-        if !dag
-            .compute_status(&node.name)
-            .map_or(false, |s| s.is_done())
-        {
+    for node in &all_nodes {
+        if dag.get_overlay_status(&node.name) != Some("done") {
             needed.insert(node.name.clone());
+            collect_upstream(dag, &node.name, &mut needed);
         }
     }
 
-    // Find done nodes that aren't needed
-    let all_nodes = dag.all_nodes();
+    // Prunable = explicitly marked done and not needed by non-done nodes
     let prunable: Vec<_> = all_nodes
         .iter()
         .filter(|n| {
-            dag.compute_status(&n.name)
-                .map_or(false, |s| s.is_done())
-                && !needed.contains(&n.name)
+            dag.get_overlay_status(&n.name) == Some("done") && !needed.contains(&n.name)
         })
         .collect();
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -70,7 +70,7 @@ pub fn format_dag(dag: &Dag, registry: &AdapterRegistry) -> String {
     if let Some(topo) = dag.topological_sort() {
         let remaining: Vec<&str> = topo
             .iter()
-            .filter(|n| dag.compute_status(&n.name) != Some(ComputedStatus::Done))
+            .filter(|n| !dag.compute_status(&n.name).map_or(false, |s| s.is_done()))
             .map(|n| n.name.as_str())
             .collect();
         if !remaining.is_empty() {
@@ -94,10 +94,8 @@ pub fn format_dag(dag: &Dag, registry: &AdapterRegistry) -> String {
     let actionable: Vec<_> = nodes
         .iter()
         .filter(|n| {
-            matches!(
-                dag.compute_status(&n.name),
-                Some(ComputedStatus::Ready) | Some(ComputedStatus::InProgress)
-            )
+            dag.compute_status(&n.name)
+                .map_or(false, |s| s.is_actionable())
         })
         .collect();
 
@@ -275,11 +273,12 @@ fn format_tree_node(
         .compute_status(name)
         .unwrap_or(ComputedStatus::Blocked);
 
-    let status_marker = match status {
-        ComputedStatus::Done => "✓",
-        ComputedStatus::InProgress => "~",
+    let status_marker = match &status {
         ComputedStatus::Ready => "●",
         ComputedStatus::Blocked => "○",
+        ComputedStatus::External(_) if status.is_done() => "✓",
+        ComputedStatus::External(_) if status.is_actionable() => "~",
+        ComputedStatus::External(_) => "◆",
     };
 
     let desc = dag

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,10 +1,10 @@
 use crate::adapter::AdapterRegistry;
-use crate::dag::{ComputedStatus, Dag};
+use crate::dag::Dag;
 use crate::resolver;
 
 /// Format the full DAG state as structured, readable output.
-/// Compact lines for done/blocked nodes, expanded with body for ready/in-progress.
-/// Bodies of expanded nodes are lazily resolved through the adapter registry.
+/// Shows raw facts — no interpretation of what statuses mean.
+/// Bodies are lazily resolved through the adapter registry.
 pub fn format_dag(dag: &Dag, registry: &AdapterRegistry) -> String {
     let mut out = String::new();
 
@@ -21,16 +21,17 @@ pub fn format_dag(dag: &Dag, registry: &AdapterRegistry) -> String {
         out.push('\n');
     }
 
-    // DAG summary — one line per node
+    // DAG summary — one line per node with raw overlay status
     out.push_str("## DAG\n\n");
     for node in &nodes {
-        let status = dag
-            .compute_status(&node.name)
-            .unwrap_or(ComputedStatus::Blocked);
         let desc = node.description.as_deref().unwrap_or("");
-
         let display_name = linkify_name(&node.name);
-        out.push_str(&format!("- **{}** [{}]", display_name, status));
+
+        if let Some(status) = dag.get_overlay_status(&node.name) {
+            out.push_str(&format!("- **{}** [{}]", display_name, status));
+        } else {
+            out.push_str(&format!("- **{}**", display_name));
+        }
         if !desc.is_empty() {
             out.push_str(&format!(" — {}", desc));
         }
@@ -40,13 +41,7 @@ pub fn format_dag(dag: &Dag, registry: &AdapterRegistry) -> String {
             let deps: Vec<String> = node
                 .upstream
                 .iter()
-                .map(|u| {
-                    let s = dag
-                        .compute_status(u)
-                        .map(|s| s.to_string())
-                        .unwrap_or_else(|| "?".to_string());
-                    format!("{} [{}]", u, s)
-                })
+                .map(|u| format_dep_ref(dag, u))
                 .collect();
             out.push_str(&format!("  depends on: {}\n", deps.join(", ")));
         }
@@ -54,29 +49,19 @@ pub fn format_dag(dag: &Dag, registry: &AdapterRegistry) -> String {
             let blocks: Vec<String> = node
                 .downstream
                 .iter()
-                .map(|d| {
-                    let s = dag
-                        .compute_status(d)
-                        .map(|s| s.to_string())
-                        .unwrap_or_else(|| "?".to_string());
-                    format!("{} [{}]", d, s)
-                })
+                .map(|d| format_dep_ref(dag, d))
                 .collect();
             out.push_str(&format!("  blocks: {}\n", blocks.join(", ")));
         }
     }
 
-    // Execution order
+    // Topological order
     if let Some(topo) = dag.topological_sort() {
-        let remaining: Vec<&str> = topo
-            .iter()
-            .filter(|n| !dag.compute_status(&n.name).map_or(false, |s| s.is_done()))
-            .map(|n| n.name.as_str())
-            .collect();
-        if !remaining.is_empty() {
+        let names: Vec<&str> = topo.iter().map(|n| n.name.as_str()).collect();
+        if !names.is_empty() {
             out.push_str(&format!(
-                "\n## Execution Order\n\n{}\n",
-                remaining.join(" → ")
+                "\n## Topological Order\n\n{}\n",
+                names.join(" → ")
             ));
         }
     }
@@ -90,32 +75,30 @@ pub fn format_dag(dag: &Dag, registry: &AdapterRegistry) -> String {
         ));
     }
 
-    // Expanded detail for ready and in-progress nodes — lazy resolution happens here
-    let actionable: Vec<_> = nodes
+    // Expanded detail for all nodes with bodies — lazy resolution happens here
+    let has_body: Vec<_> = nodes
         .iter()
-        .filter(|n| {
-            dag.compute_status(&n.name)
-                .map_or(false, |s| s.is_actionable())
-        })
+        .filter(|n| !n.body.is_empty())
         .collect();
 
-    if !actionable.is_empty() {
-        out.push_str("\n## Ready / In-Progress\n");
+    if !has_body.is_empty() {
+        out.push_str("\n## Detail\n");
 
-        for node in &actionable {
-            let status = dag.compute_status(&node.name).unwrap();
+        for node in &has_body {
             let display_name = linkify_name(&node.name);
-            out.push_str(&format!("\n### {} [{}]\n", display_name, status));
+            if let Some(status) = dag.get_overlay_status(&node.name) {
+                out.push_str(&format!("\n### {} [{}]\n", display_name, status));
+            } else {
+                out.push_str(&format!("\n### {}\n", display_name));
+            }
 
             if let Some(desc) = &node.description {
                 out.push_str(&format!("\n{}\n", desc));
             }
 
-            if !node.body.is_empty() {
-                // Lazy resolution: resolve @scheme:reference lines through adapters
-                let resolved = resolver::resolve_body(&node.body, registry);
-                out.push_str(&format!("\n{}\n", resolved));
-            }
+            // Lazy resolution: resolve @scheme:reference lines through adapters
+            let resolved = resolver::resolve_body(&node.body, registry);
+            out.push_str(&format!("\n{}\n", resolved));
 
             if !node.context.is_empty() {
                 out.push_str("\n**Context:**\n");
@@ -127,6 +110,15 @@ pub fn format_dag(dag: &Dag, registry: &AdapterRegistry) -> String {
     }
 
     out
+}
+
+/// Format a dependency reference with its overlay status if present.
+fn format_dep_ref(dag: &Dag, name: &str) -> String {
+    if let Some(status) = dag.get_overlay_status(name) {
+        format!("{} [{}]", name, status)
+    } else {
+        name.to_string()
+    }
 }
 
 /// Convert `@github:owner/repo#N` names into markdown links.
@@ -168,12 +160,13 @@ pub fn format_node(dag: &Dag, name: &str, registry: &AdapterRegistry) -> String 
         return out;
     };
 
-    let status = dag
-        .compute_status(name)
-        .unwrap_or(ComputedStatus::Blocked);
     let display_name = linkify_name(name);
 
-    out.push_str(&format!("## {} [{}]\n", display_name, status));
+    if let Some(status) = dag.get_overlay_status(name) {
+        out.push_str(&format!("## {} [{}]\n", display_name, status));
+    } else {
+        out.push_str(&format!("## {}\n", display_name));
+    }
 
     if let Some(desc) = &node.description {
         out.push_str(&format!("\n{}\n", desc));
@@ -183,13 +176,7 @@ pub fn format_node(dag: &Dag, name: &str, registry: &AdapterRegistry) -> String 
         let deps: Vec<String> = node
             .upstream
             .iter()
-            .map(|u| {
-                let s = dag
-                    .compute_status(u)
-                    .map(|s| s.to_string())
-                    .unwrap_or_else(|| "?".to_string());
-                format!("{} [{}]", u, s)
-            })
+            .map(|u| format_dep_ref(dag, u))
             .collect();
         out.push_str(&format!("\n**depends on:** {}\n", deps.join(", ")));
     }
@@ -198,13 +185,7 @@ pub fn format_node(dag: &Dag, name: &str, registry: &AdapterRegistry) -> String 
         let blocks: Vec<String> = node
             .downstream
             .iter()
-            .map(|d| {
-                let s = dag
-                    .compute_status(d)
-                    .map(|s| s.to_string())
-                    .unwrap_or_else(|| "?".to_string());
-                format!("{} [{}]", d, s)
-            })
+            .map(|d| format_dep_ref(dag, d))
             .collect();
         out.push_str(&format!("**blocks:** {}\n", blocks.join(", ")));
     }
@@ -227,6 +208,7 @@ pub fn format_node(dag: &Dag, name: &str, registry: &AdapterRegistry) -> String 
 }
 
 /// Format the DAG as an ASCII dependency tree.
+/// Shows raw overlay status — no interpretation.
 pub fn format_graph(dag: &Dag) -> String {
     let mut out = String::new();
 
@@ -269,17 +251,10 @@ fn format_tree_node(
         "├── "
     };
 
-    let status = dag
-        .compute_status(name)
-        .unwrap_or(ComputedStatus::Blocked);
-
-    let status_marker = match &status {
-        ComputedStatus::Ready => "●",
-        ComputedStatus::Blocked => "○",
-        ComputedStatus::External(_) if status.is_done() => "✓",
-        ComputedStatus::External(_) if status.is_actionable() => "~",
-        ComputedStatus::External(_) => "◆",
-    };
+    let status_tag = dag
+        .get_overlay_status(name)
+        .map(|s| format!("[{}] ", s))
+        .unwrap_or_default();
 
     let desc = dag
         .get_node(name)
@@ -291,15 +266,15 @@ fn format_tree_node(
     // If already printed (diamond merge), show a back-reference
     if !printed.insert(name.to_string()) {
         out.push_str(&format!(
-            "{}{}{} {} (→ see above)\n",
-            prefix, connector, status_marker, display
+            "{}{}{}{} (→ see above)\n",
+            prefix, connector, status_tag, display
         ));
         return;
     }
 
     out.push_str(&format!(
-        "{}{}{} {} {}\n",
-        prefix, connector, status_marker, display, desc
+        "{}{}{}{} {}\n",
+        prefix, connector, status_tag, display, desc
     ));
 
     let mut children: Vec<_> = dag.downstream_of(name);

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,18 +1,11 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-/// Status values for a node.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ManualStatus {
-    InProgress,
-    Done,
-}
-
 const STATUS_FILE: &str = ".amos-status";
 
 /// Read the status file from the scan root.
-/// Returns a map of node name → status.
-pub fn read_status_file(scan_root: &Path) -> HashMap<String, ManualStatus> {
+/// Returns a map of node name → status string.
+pub fn read_status_file(scan_root: &Path) -> HashMap<String, String> {
     let path = scan_root.join(STATUS_FILE);
     let content = match std::fs::read_to_string(&path) {
         Ok(c) => c,
@@ -22,21 +15,23 @@ pub fn read_status_file(scan_root: &Path) -> HashMap<String, ManualStatus> {
     let mut statuses = HashMap::new();
     for line in content.lines() {
         let trimmed = line.trim();
-        if let Some(name) = parse_status_line(trimmed) {
-            statuses.insert(name.0, name.1);
+        if let Some((name, status)) = parse_status_line(trimmed) {
+            statuses.insert(name, status);
         }
     }
     statuses
 }
 
 /// Write or update a single node's status in the status file.
-pub fn write_status(scan_root: &Path, name: &str, status: ManualStatus) -> std::io::Result<()> {
+pub fn write_status(scan_root: &Path, name: &str, status: &str) -> std::io::Result<()> {
     let path = scan_root.join(STATUS_FILE);
     let mut entries = read_entries(&path);
 
+    // Canonical aliases for compact display
     let symbol = match status {
-        ManualStatus::Done => "x",
-        ManualStatus::InProgress => "~",
+        "done" => "x",
+        "in-progress" => "~",
+        other => other,
     };
 
     // Update existing or append
@@ -73,10 +68,12 @@ struct StatusEntry {
     name: String,
 }
 
-fn parse_status_line(line: &str) -> Option<(String, ManualStatus)> {
-    // - [x] node-name  → Done
-    // - [~] node-name  → InProgress
+fn parse_status_line(line: &str) -> Option<(String, String)> {
+    // - [x] node-name  → "done"
+    // - [~] node-name  → "in-progress"
     // - [ ] node-name  → skip (not started, no status)
+    // - [closed] node  → "closed"
+    // - [In Review] n  → "In Review"
     let rest = line.strip_prefix("- [")?;
     let (symbol, rest) = rest.split_once(']')?;
     let name = rest.trim_start_matches(' ').trim();
@@ -85,11 +82,14 @@ fn parse_status_line(line: &str) -> Option<(String, ManualStatus)> {
         return None;
     }
 
-    match symbol.trim() {
-        "x" => Some((name.to_string(), ManualStatus::Done)),
-        "~" => Some((name.to_string(), ManualStatus::InProgress)),
-        _ => None, // " " or anything else = not started
-    }
+    let status = match symbol.trim() {
+        "x" => "done",
+        "~" => "in-progress",
+        "" | " " => return None, // not started
+        other => other,
+    };
+
+    Some((name.to_string(), status.to_string()))
 }
 
 fn read_entries(path: &Path) -> Vec<StatusEntry> {
@@ -144,22 +144,22 @@ mod tests {
     #[test]
     fn test_write_and_read() {
         let dir = setup();
-        write_status(dir.path(), "task-a", ManualStatus::Done).unwrap();
-        write_status(dir.path(), "task-b", ManualStatus::InProgress).unwrap();
+        write_status(dir.path(), "task-a", "done").unwrap();
+        write_status(dir.path(), "task-b", "in-progress").unwrap();
 
         let statuses = read_status_file(dir.path());
-        assert_eq!(statuses.get("task-a"), Some(&ManualStatus::Done));
-        assert_eq!(statuses.get("task-b"), Some(&ManualStatus::InProgress));
+        assert_eq!(statuses.get("task-a").map(|s| s.as_str()), Some("done"));
+        assert_eq!(statuses.get("task-b").map(|s| s.as_str()), Some("in-progress"));
     }
 
     #[test]
     fn test_update_existing() {
         let dir = setup();
-        write_status(dir.path(), "task-a", ManualStatus::InProgress).unwrap();
-        write_status(dir.path(), "task-a", ManualStatus::Done).unwrap();
+        write_status(dir.path(), "task-a", "in-progress").unwrap();
+        write_status(dir.path(), "task-a", "done").unwrap();
 
         let statuses = read_status_file(dir.path());
-        assert_eq!(statuses.get("task-a"), Some(&ManualStatus::Done));
+        assert_eq!(statuses.get("task-a").map(|s| s.as_str()), Some("done"));
 
         // Verify file has only one entry
         let content = fs::read_to_string(dir.path().join(".amos-status")).unwrap();
@@ -169,13 +169,13 @@ mod tests {
     #[test]
     fn test_clear_status() {
         let dir = setup();
-        write_status(dir.path(), "task-a", ManualStatus::Done).unwrap();
-        write_status(dir.path(), "task-b", ManualStatus::Done).unwrap();
+        write_status(dir.path(), "task-a", "done").unwrap();
+        write_status(dir.path(), "task-b", "done").unwrap();
         clear_status(dir.path(), "task-a").unwrap();
 
         let statuses = read_status_file(dir.path());
         assert!(!statuses.contains_key("task-a"));
-        assert_eq!(statuses.get("task-b"), Some(&ManualStatus::Done));
+        assert_eq!(statuses.get("task-b").map(|s| s.as_str()), Some("done"));
     }
 
     #[test]
@@ -185,8 +185,24 @@ mod tests {
         fs::write(dir.path().join(".amos-status"), content).unwrap();
 
         let statuses = read_status_file(dir.path());
-        assert_eq!(statuses.get("done-task"), Some(&ManualStatus::Done));
-        assert_eq!(statuses.get("wip-task"), Some(&ManualStatus::InProgress));
+        assert_eq!(statuses.get("done-task").map(|s| s.as_str()), Some("done"));
+        assert_eq!(statuses.get("wip-task").map(|s| s.as_str()), Some("in-progress"));
         assert!(!statuses.contains_key("pending-task")); // [ ] = no status
+    }
+
+    #[test]
+    fn test_arbitrary_status_strings() {
+        let dir = setup();
+        write_status(dir.path(), "task-a", "closed").unwrap();
+        write_status(dir.path(), "task-b", "In Review").unwrap();
+
+        let statuses = read_status_file(dir.path());
+        assert_eq!(statuses.get("task-a").map(|s| s.as_str()), Some("closed"));
+        assert_eq!(statuses.get("task-b").map(|s| s.as_str()), Some("In Review"));
+
+        // Verify raw file content uses the strings directly
+        let content = fs::read_to_string(dir.path().join(".amos-status")).unwrap();
+        assert!(content.contains("- [closed] task-a"));
+        assert!(content.contains("- [In Review] task-b"));
     }
 }

--- a/src/url_adapter.rs
+++ b/src/url_adapter.rs
@@ -1,4 +1,5 @@
 use anyhow::{bail, Context, Result};
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -31,7 +32,7 @@ impl Adapter for UrlAdapter {
             Ok(ResourceFields {
                 name: None,
                 description: None,
-                status: None,
+                facts: HashMap::new(),
                 body: Some(format!("![{}]({})", filename, local_path.display())),
             })
         } else {
@@ -41,7 +42,7 @@ impl Adapter for UrlAdapter {
             Ok(ResourceFields {
                 name: None,
                 description: None,
-                status: None,
+                facts: HashMap::new(),
                 body: Some(if ext.is_empty() {
                     content
                 } else {


### PR DESCRIPTION
## Summary

- Adds plan node #33 documenting the status model problem and fix
- `ManualStatus { Done, InProgress }` is too narrow — Jira/GitHub/Linear have arbitrary workflow states
- Adapter-resolved status (`ResourceFields.status`) is returned but ignored by the DAG — `compute_status()` only reads `.amos-status`
- Six files need changes: `status.rs`, `adapter.rs`, `gh_adapter.rs`, `dag.rs`, `external_adapter.rs`, `output.rs`

## Test plan

- [ ] `ManualStatus` → `String` throughout, `.amos-status` accepts arbitrary status strings
- [ ] `ResourceFields.status` becomes `Option<String>`
- [ ] GitHub adapter returns raw state (`"closed"`, `"open"`) instead of mapping to enum
- [ ] `compute_status()` checks adapter-resolved status, not just `.amos-status` overlay
- [ ] External adapter passes through JSON status field as-is
- [ ] `format_dag()` displays real status strings in brackets
- [ ] Existing tests updated to use string-based status

🤖 Generated with [Claude Code](https://claude.com/claude-code)