### PR TITLE
CI — cross-platform release builds via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [ci-release]
+    branches: [main]
+    tags: ["v*"]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,86 @@
+name: CI
+
+on:
+  push:
+    branches: [ci-release]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test
+
+  build:
+    needs: test
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            artifact: amos-linux-x86_64
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            artifact: amos-darwin-x86_64
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            artifact: amos-darwin-aarch64
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+            artifact: amos-windows-x86_64.exe
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Install musl tools
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Rename binary
+        shell: bash
+        run: |
+          src="target/${{ matrix.target }}/release/amos"
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            src="${src}.exe"
+          fi
+          cp "$src" "${{ matrix.artifact }}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*
+          generate_release_notes: true


### PR DESCRIPTION
## Summary

- GitHub Actions workflow for cross-platform release builds
- Tests run on every push/PR to main
- Builds binaries for Linux (musl static), macOS (x86_64 + aarch64), Windows
- Uploads artifacts per platform
- Creates GitHub Release with all binaries on `v*` tag push
- Verified: all 4 platform builds pass, Linux musl binary tested locally (statically linked, runs correctly)

## Test plan

- [x] CI passes on all 4 targets (verified on ci-release branch)
- [x] Linux musl binary tested locally — `amos --help`, `amos graph` work
- [x] Binary is statically linked (no shared lib dependencies)
- [ ] Tag a `v0.1.0` release to verify the release job uploads artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)