### PR TITLE
docs(skills): rewrite amos skills with explicit invocation paths

### DIFF
--- a/.claude/skills/amos-create/SKILL.md
+++ b/.claude/skills/amos-create/SKILL.md
@@ -1,11 +1,79 @@
 ---
 name: amos-create
 description: >
-  Create a new amos node with proper frontmatter.
+  Scaffold a new amos node with proper frontmatter. Use when the user wants to add a new
+  ticket, task, or plan entry tracked by amos. Produces a markdown file with the canonical
+  `@github:<owner>/<repo>#<N>` name, a description, dependencies, and the adapter block.
 disable-model-invocation: true
-argument-hint: "<name> <description>"
-allowed-tools: Bash(amos:*)
+argument-hint: "<issue-number> <one-line-description>"
+allowed-tools: Bash
 ---
 
-Create a markdown file with `whoami: amos` frontmatter.
-See references/node-format.md for the template.
+When the user invokes `/amos-create`, scaffold a new node using the template below. See also
+`references/node-format.md` for the bare template.
+
+## Inputs
+
+- `<issue-number>` — the GitHub (or other adapter) issue number this node represents.
+- `<one-line-description>` — short routing hint (free-form). This is not the identifier.
+- Determine `<owner>/<repo>` from the git remote of the current project, or ask the user if
+  ambiguous.
+
+## Output: `plan/<N>-<kebab-slug>.md`
+
+```markdown
+---
+whoami: amos
+name: "@github:<owner>/<repo>#<N>"
+status: pending
+description: "<one-line routing hint>"
+github_issue: <N>
+dependencies:
+  - "down:@github:<owner>/<repo>#<M>"   # this node blocks M
+  - "up:@github:<owner>/<repo>#<K>"     # this node waits on K
+adapters:
+  github: builtin
+---
+
+@github:<owner>/<repo>#<N>
+
+Local agent instructions below the adapter reference. These persist locally
+even when the remote issue body changes.
+```
+
+## Naming rules — strict
+
+- `name:` is an **identifier**, not a title. Always `@github:<owner>/<repo>#<N>`.
+- Put the human-readable title in `description:`.
+- `github_issue:` should match the `#N` in the name.
+- Filename: `<N>-<short-kebab-slug>.md` under the `plan/` directory.
+
+**Why this matters:** every `down:` / `up:` edge references another node by its literal `name:`
+string. If you put "Refactor auth module" in `name:` and later rename it to "Refactor auth", every
+edge pointing at the node breaks silently — the DAG edge resolver just finds no match and drops
+it. Canonical `@github:...` names never need renaming; they're stable as long as the issue exists.
+
+## Dependencies
+
+- `down:<target>` — this node blocks `<target>`; `<target>` is waiting on this.
+- `up:<target>` — this node is waiting on `<target>`; `<target>` blocks this.
+
+Prefer writing a single `down:` on the upstream node over an `up:` on the downstream. That gives
+each edge exactly one source of truth and matches how the CLI is typically used.
+
+## Adapters
+
+`adapters: { github: builtin }` is the default and enables the built-in GitHub adapter. The
+adapter is what lets `@github:<owner>/<repo>#<N>` references in the body resolve to the issue's
+content. Leave as `builtin` unless wiring a custom adapter.
+
+## After scaffolding
+
+Run **amos-graph** to confirm the new node appears and its `down:` / `up:` edges resolve:
+
+```bash
+"$HOME/.local/bin/amos" graph | grep "#<N>"
+```
+
+If an edge target doesn't exist, the new node will appear at the top level (orphaned) instead
+of nested under its parent.

--- a/.claude/skills/amos-graph/SKILL.md
+++ b/.claude/skills/amos-graph/SKILL.md
@@ -1,12 +1,69 @@
 ---
 name: amos-graph
 description: >
-  Show amos dependency structure — names, statuses, and
-  relationships without resolving full content. Lightweight
-  structural query.
-allowed-tools: Bash(amos:*)
+  Print the amos dependency tree as a nested ASCII graph. Use when the user asks about open
+  tasks, the roadmap, what's next, what's blocked, what depends on X, or wants a structural
+  view of the plan. Returns every node with status and a short description; does NOT resolve
+  `@github:...` references (use amos-show for full content). Trigger on phrases like "what's
+  on my plate", "what's open", "show me the DAG", "what's blocking X", "what depends on Y",
+  "where are we on <umbrella>".
+allowed-tools: Bash
 ---
 
-Run `amos graph` to see the dependency tree with node names,
-statuses, and relationships. No content resolution — just
-the structure.
+Run from the project root (the directory containing amos-scanned markdown files):
+
+```bash
+"$HOME/.local/bin/amos" graph
+```
+
+## Output format
+
+Nested tree, indent encodes depth. Each line looks like:
+
+```
+[state=OPEN] #319 GPU capability-based access (sandbox + escalate) — Umbrella — replace runtime-phase checks ...
+    ├── [state=CLOSED] #320 Design doc: ... — Write the design doc gating all downstream work ...
+    ├── [state=CLOSED] #321 Introduce GpuContext... — Add the two capability types as thin newtype wrappers ...
+    └── [state=OPEN] #326 Learning doc: ... — Capture the "why" of the sandbox/escalate pattern ...
+        ├── [state=CLOSED] #325 (→ see above)
+        ├── [state=OPEN] #369 Polyglot escalate: ... — Follow-up to #325. Extend the polyglot escalate IPC ...
+        └── [state=OPEN] #370 xtask: JTD discriminator schemas — Update xtask/src/generate_schemas.rs ...
+```
+
+Legend:
+- `[state=OPEN]` / `[state=CLOSED]` — lifecycle state (from the adapter, e.g. GitHub issue state).
+- `[labels=...]` — tracker labels, when present.
+- `#N` — GitHub issue number, derived from the canonical `@github:<owner>/<repo>#N` node name.
+- Text after the em-dash — the node's `description:` field (a routing hint).
+- `(→ see above)` — back-reference; the subtree was already printed earlier.
+
+## When to use
+
+- "What's next" / "what's on my plate" / "what's open"
+- "What's blocking X" / "what does Y depend on"
+- Finding the next unblocked task under an umbrella
+- Orientation in a new or unfamiliar amos-tracked project
+- Spotting broken edges (orphan nodes appear at the top level instead of nested)
+
+## When NOT to use
+
+- Need the full resolved body of a single node (GitHub issue text, etc.) → use **amos-show**.
+- Just want the raw markdown of one plan file → use **Read** on the file directly (no
+  network, much faster).
+- Need to post a comment to the tracker → use **amos-notify**.
+
+## Filtering large trees
+
+Output can be long (hundreds of lines on mature projects). To zoom in, pipe through grep with
+context:
+
+```bash
+# Show a specific umbrella and its children
+"$HOME/.local/bin/amos" graph | grep -A 30 "#319 "
+
+# Find all open tasks
+"$HOME/.local/bin/amos" graph | grep "state=OPEN"
+
+# Find orphan nodes (no parent, broken edges)
+"$HOME/.local/bin/amos" graph | grep -B 0 "^[A-Z\[]"
+```

--- a/.claude/skills/amos-notify/SKILL.md
+++ b/.claude/skills/amos-notify/SKILL.md
@@ -1,12 +1,67 @@
 ---
 name: amos-notify
 description: >
-  Send a message to a node's source system through its adapter.
+  Post a message to a node's source system through its adapter. For a `@github:...` node,
+  this creates a comment on the referenced issue. Use when the user wants to share status,
+  results, or context with everyone watching the upstream tracker — not for local scratch
+  notes. The message is visible to anyone with access to the tracker.
 disable-model-invocation: true
-argument-hint: "<node> <message>"
-allowed-tools: Bash(amos:*)
+argument-hint: "<node-name> <message>"
+allowed-tools: Bash
 ---
 
-Run `amos notify <node> <message>` to send a freeform message
-to the node's source system. The adapter decides how to deliver
-it (e.g. GitHub issue comment, Slack message).
+```bash
+"$HOME/.local/bin/amos" notify "<node-name>" "<message>"
+```
+
+`<node-name>` must be the canonical `name:` value of an amos node:
+
+```bash
+"$HOME/.local/bin/amos" notify "@github:tatolab/streamlib#326" "Dependency edges updated — #326 now sits behind #369 and #370 per the umbrella ordering."
+```
+
+## Adapters
+
+- **github (builtin)** — posts the message as a new comment on the GitHub issue named by the
+  node. Supports GitHub-flavored markdown (code fences, links, lists, checkboxes).
+
+## Examples
+
+Short status update:
+
+```bash
+"$HOME/.local/bin/amos" notify "@github:tatolab/streamlib#319" "Phase 1 merged. Starting phase 2 now."
+```
+
+Longer comment with markdown — use a HEREDOC to keep the quoting sane:
+
+```bash
+MSG="$(cat <<'EOF'
+## Progress update
+
+- Landed the canonical-name migration (80 plan files).
+- Reattached #322 under #319 (was silently orphaned by a stale rename).
+- Added missing #369 / #370 edges under #326.
+
+Next: working on #370 (xtask JTD discriminator).
+EOF
+)"
+"$HOME/.local/bin/amos" notify "@github:tatolab/streamlib#319" "$MSG"
+```
+
+## When to use
+
+- Reporting progress to everyone watching the issue
+- Closing-out notes when finishing a task
+- Flagging a blocker that needs the issue reporter's attention
+
+## When NOT to use
+
+- Notes meant only for yourself or the agent → put them in the plan file body instead.
+- Communicating privately with a teammate → use a DM, not an issue comment.
+- Anything sensitive → remember the tracker is visible to everyone with repo access.
+
+## Verification
+
+After posting, the comment appears on the issue page. `amos show "<node-name>"` will re-fetch
+the issue and include the new comment in the resolved body.

--- a/.claude/skills/amos-show/SKILL.md
+++ b/.claude/skills/amos-show/SKILL.md
@@ -1,11 +1,46 @@
 ---
 name: amos-show
 description: >
-  Resolve a single amos node fully by name. Use when you need
-  the complete resolved content of a specific whoami: amos node.
-allowed-tools: Bash(amos:*)
+  Resolve a single amos node to its fully expanded content — frontmatter summary plus the
+  remote body fetched via the adapter (e.g. GitHub issue body). Use when the user asks about
+  a specific ticket or node ("tell me about #322", "what's #319 about", "show me the MoQ
+  plan"). Use amos-graph for structural views across many nodes, and Read for just the local
+  markdown without a remote fetch.
+allowed-tools: Bash
 ---
 
-Run `amos show <name>` to get a single node with all references
-resolved and content fully expanded. Pass the node's `name` field
-value (e.g. `amos show "@github:tatolab/streamlib#143"`).
+```bash
+"$HOME/.local/bin/amos" show "<node-name>"
+```
+
+`<node-name>` must be the node's canonical `name:` value:
+
+```bash
+"$HOME/.local/bin/amos" show "@github:tatolab/streamlib#319"
+```
+
+## Output
+
+The node's frontmatter as a summary, followed by the resolved body — which, for a
+`@github:...` node, is the fetched GitHub issue body plus any local agent instructions
+kept below the adapter reference in the plan file.
+
+## When to use
+
+- "Tell me about issue #N" / "what's #N about"
+- Need the remote issue body inline alongside local plan instructions
+- Reviewing a single node's full context before starting work on it
+
+## When NOT to use
+
+- Want the DAG / dependency structure → use **amos-graph**.
+- Want just the raw local markdown (no network fetch) → use **Read** on the plan file
+  directly. Much faster, and the local agent instructions are usually enough.
+- Want to post a comment back to the tracker → use **amos-notify**.
+
+## If the name doesn't resolve
+
+`amos show` matches by the literal `name:` field in the file's frontmatter. If a node still
+has a free-text name (drift from canonical form — see the **amos** skill), pass that literal
+string. Prefer fixing the node to canonical `@github:<owner>/<repo>#<N>` form first — broken
+identifiers silently break dependency edges elsewhere in the DAG.

--- a/.claude/skills/amos/SKILL.md
+++ b/.claude/skills/amos/SKILL.md
@@ -1,17 +1,73 @@
 ---
 name: amos
 description: >
-  Activate when you see whoami: amos in markdown frontmatter.
-  Amos is a CLI preprocessor that resolves content in markdown
-  files and builds dependency graphs.
-allowed-tools: Bash(amos:*)
+  Load when working with amos nodes — markdown files carrying `whoami: amos` frontmatter — or when
+  the user refers to "the plan", "the DAG", "the roadmap", "the tickets", "what's next", or
+  similar work-tracking concepts. Installs the amos conventions (canonical naming, node format,
+  when to reach for which sub-skill) into context so amos-graph, amos-show, amos-create, and
+  amos-notify can be used correctly. Does not run the CLI on its own.
 ---
 
-Amos preprocesses markdown files containing `whoami: amos` frontmatter.
-It resolves references in the content through adapters, caches results
-locally, and returns fully formed output.
+# Amos
 
-Run `amos` to preprocess all nodes and see the dependency graph with
-resolved content for actionable nodes.
+Amos is a CLI preprocessor over markdown files. Each file with `whoami: amos` frontmatter is a
+**node** in a dependency graph. Typical use: project plans, tickets, tasks, or work items that
+span external trackers (GitHub issues, etc.) with `down:` / `up:` edges between them.
 
-!`amos 2>/dev/null || true`
+## The canonical name rule — NON-NEGOTIABLE
+
+Every node has an identifier in its `name:` field. Use the adapter-qualified form:
+
+```yaml
+name: "@github:<owner>/<repo>#<issue-number>"
+```
+
+e.g. `name: "@github:tatolab/streamlib#326"`.
+
+**Never put human-readable text in `name:`.** `name:` is a stable identifier used for edge
+resolution. Every `down:` and `up:` edge references another node by this string, so edits to it
+silently break the DAG. Put titles, summaries, and routing hints in `description:` (free-form).
+
+If you see a node with a free-text name (e.g. `name: "Learning doc: ..."`), that's drift and
+should be fixed — rename to the canonical form and move the free text into `description:`.
+
+## Node file format
+
+```markdown
+---
+whoami: amos
+name: "@github:<owner>/<repo>#<N>"
+status: pending | in-progress | completed
+description: "<short routing hint — free-form>"
+github_issue: <N>
+dependencies:
+  - "down:@github:<owner>/<repo>#<M>"   # this node blocks M
+  - "up:@github:<owner>/<repo>#<K>"     # this node waits on K
+adapters:
+  github: builtin
+---
+
+@github:<owner>/<repo>#<N>
+
+Local agent instructions below the adapter reference. These stay local even when
+the remote issue body is resolved by the adapter.
+```
+
+Filename convention: `<N>-<short-kebab-slug>.md` under `plan/` (or wherever amos scans).
+
+## Sub-skill routing
+
+- **amos-graph** — print the full dependency tree. Use for "what's open", "what's next",
+  "what's blocked", "show me the roadmap", orientation queries.
+- **amos-show** — resolve a single node to full content including `@`-references. Use for
+  "tell me about #N".
+- **amos-create** — scaffold a new node (user-invoked via `/amos-create`).
+- **amos-notify** — post a message to a node's source system, e.g. GitHub issue comment
+  (user-invoked via `/amos-notify`).
+
+## The CLI
+
+Installed binary: `$HOME/.local/bin/amos` (placed there by `tatolab/amos`'s `install.sh`).
+
+Sub-skills invoke it as `"$HOME/.local/bin/amos" <subcommand>`. Don't prefix with `bash` — it's a
+compiled binary, not a script.


### PR DESCRIPTION
## Summary

- Rewrites all five installed skill files (amos, amos-graph, amos-show, amos-create, amos-notify) with richer descriptions, explicit `\$HOME/.local/bin/amos` invocation paths, and when-to-use / when-not-to-use sections.
- Fixes the PATH-dependence that caused skills to misbehave when `~/.local/bin` wasn't on the agent's PATH.
- Removes the noisy `!amos` context hook from the top-level amos skill.
- Inlines the node-format template into amos-create (the old version pointed at a `references/` file that `install.sh` never copied).

## Test plan

- [x] All 5 skills still resolve and invoke correctly from `~/.claude/skills/`
- [x] `amos-graph`, `amos-show`, `amos-notify`, `amos-create`, and the top-level `amos` skill each trigger on their respective natural-language phrasings

## Follow-ups

- `install.sh` still doesn't copy `references/` subdirectories; fix that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)