### PR TITLE
feat: typed-edge DAG, milestone focus, and amos:next workflow

### DIFF
--- a/.claude/skills/amos-focus/SKILL.md
+++ b/.claude/skills/amos-focus/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: amos-focus
+description: >
+  Set the milestone the user is currently working on. `amos next`, `amos
+  blocked`, and `amos graph` scope their output to this milestone once set.
+  Use when the user says "let's work on <milestone>", "focus on <milestone>",
+  "switch to <milestone>", or wants to check which milestone is currently
+  active. Accepts free-form milestone text — the tool resolves it against
+  the adapter's known titles.
+argument-hint: "<milestone-title> | --clear | (no args → print current)"
+allowed-tools: Bash
+---
+
+```bash
+"$HOME/.local/bin/amos" focus "<milestone title>"
+"$HOME/.local/bin/amos" focus --clear
+"$HOME/.local/bin/amos" focus              # print current
+```
+
+Focus is stored in `.amosrc.toml` at the scan root — persistent across
+sessions. Scopes `amos next`, `amos blocked`, `amos orphans`, and (future)
+`amos graph --focused` to items in that milestone.
+
+## When to use
+
+- "Let's work on GPU Capability Rewrite" → `amos focus "GPU Capability Rewrite"`
+- "What milestone am I on?" → `amos focus` (no args)
+- "Clear focus, show me everything" → `amos focus --clear`
+
+## Discovering milestone titles
+
+If the user doesn't know the exact title, list them first:
+
+```bash
+"$HOME/.local/bin/amos" milestones
+```
+
+Prints every milestone the adapter knows about with open/closed counts and a
+`*` marker on the currently focused one. Then feed the exact string back to
+`amos focus "<title>"`.
+
+## Interaction with `amos next`
+
+Once focused, `amos next` only returns ready-to-start nodes **in that
+milestone**. If the milestone has nothing ready (e.g. all remaining items are
+blocked by each other or by closed adapter nodes), `amos next` exits with a
+helpful message naming the focused milestone.

--- a/.claude/skills/amos-next/SKILL.md
+++ b/.claude/skills/amos-next/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: amos-next
+description: >
+  Pick up and execute the next ready-to-start issue from the focused milestone,
+  end-to-end: announce, gate on user confirmation, branch, do the work, run
+  the tests listed in the issue body, open a PR, report. This is the skill to
+  invoke when the user says "continue", "next task", "what's next", "pick up
+  where we left off", "work on the next issue", "keep going", or similar. It
+  replaces any project-local PROMPT.md protocol.
+allowed-tools: Bash
+---
+
+# Task execution protocol — `/amos:next`
+
+You are executing the next ready-to-start issue from the focused milestone.
+The protocol below is authoritative — follow it in order.
+
+## Prereqs
+
+- The project's `CLAUDE.md` has already been loaded into context — follow it.
+
+## Step 0 — Focus triage
+
+Check whether a milestone is currently focused and whether it still has
+actionable work:
+
+```bash
+"$HOME/.local/bin/amos" focus --dir <project-root>        # prints current focus, or "no milestone currently focused"
+"$HOME/.local/bin/amos" milestones --dir <project-root>   # per-milestone open / ready / done counts
+```
+
+Handle these four cases:
+
+**(a) No focus set.** Run `amos milestones`, present a ranked list of
+candidate milestones (see *Ranking* below), and wait for the user to pick
+via `/amos:focus "<title>"`. Do NOT pick for them.
+
+**(b) Focus is set but has `0 open`.** The milestone is done. Congratulate
+the user, suggest closing it in GitHub (`gh milestone close <number>` — use
+`gh api repos/<owner>/<repo>/milestones` to find the number), then present
+ranked candidates for the next milestone.
+
+**(c) Focus is set, `open > 0` but `ready == 0`.** The milestone's remaining
+work is blocked. Run `amos blocked` to see the chain and, for each blocked
+item, its open blockers. Then either:
+- If the gating blocker is in another milestone, recommend `/amos:focus`
+  to that milestone so the user can unstick this one.
+- If the chain is internal, recommend the earliest blocker-free item (or
+  explain the circular/deadlocked case if any).
+
+**(d) Focus is set, `ready >= 1`.** Continue to Step 1 below.
+
+## Ranking recommendations
+
+When proposing milestones, use this heuristic (sort descending):
+
+1. **Exclude** anything disqualified — milestones whose every open item is
+   labeled `frozen`, or whose description starts with `[BLOCKED` or contains
+   "do not start". Call these out separately as "deferred / blocked —
+   skipping."
+2. **Prefer** higher `ready / open` ratio — milestones where most open
+   items can start today.
+3. **Prefer** smaller `open` counts — a 1- or 2-item milestone closes fast
+   and gives a real deliverable.
+4. **Prefer** milestones whose items are `blocked_by` the focused milestone
+   not at all (i.e. standalone) or that unblock other milestones (items in
+   other milestones' `blocked_by` pointing at this one).
+5. **Tiebreak** alphabetical.
+
+Emit 3–5 candidates. For each, one line on why-to-start or why-to-defer.
+Conclude with: "Run `/amos:focus "<title>"` to pick one."
+
+## Step 1 — Find the next issue (inside the focused milestone)
+
+```bash
+"$HOME/.local/bin/amos" next --dir <project-root>
+```
+
+If there's more than one ready item, **ask the user to pick** — don't choose
+for them. Show each with its `#N — title` line.
+
+## Step 2 — Load context for the chosen issue
+
+For the chosen `<issue>` (e.g. `@github:tatolab/streamlib#326`):
+
+```bash
+# Full issue: description, exit criteria, tests, comments, labels.
+gh issue view <N> --repo <owner>/<repo> --json title,body,state,labels,milestone,comments
+
+# Optional: any local AI notes in an amos plan file.
+"$HOME/.local/bin/amos" show "<issue>"
+```
+
+Then, for each label on the issue, look for a matching workflow file in the
+project's `.claude/workflows/` directory:
+
+```bash
+ls <project-root>/.claude/workflows/
+# If <label>.md exists, read it — it carries specialty context for that kind
+# of work (e.g. video-e2e.md, ci.md, macos.md).
+```
+
+Read every matching workflow file into context before starting.
+
+## Step 3 — Announce + gate on confirmation
+
+Emit exactly this block, filled in:
+
+```
+## Starting Task
+
+- **Issue**: #<N> — <title>
+- **Milestone**: <milestone title>
+- **Labels**: <label1>, <label2>
+- **Loaded workflows**: <list of .claude/workflows/*.md read, or "none">
+- **Branch**: `<branch-name>`
+- **Summary**: <1–2 sentence plan from the issue Description>
+- **Exit criteria**: <count, from issue Exit criteria section>
+- **Tests to run as gate**: <count, from issue Tests/validation section>
+- **Files in scope**: <list — from issue + workflow context>
+- **Estimated scope**: small | medium | large
+
+Proceed? [y/n]
+```
+
+**Wait for explicit user confirmation.** Do not proceed on silence.
+
+## Step 4 — Branch
+
+```bash
+git checkout main && git pull origin main
+git checkout -b <branch-name>
+```
+
+Branch name convention: `<type>/<slug>-<issue-num>` where `<type>` is
+`feat` / `fix` / `refactor` / `docs` / `test` / `chore` depending on
+the issue. Use the shortest slug that's still readable.
+
+## Step 5 — Do the work
+
+- Scope: strictly the issue's Exit criteria. Anything else → note as a
+  follow-up, do not touch.
+- Honor every rule in `CLAUDE.md` and in the loaded workflow files.
+- `cargo check` (or project-specific equivalent) frequently.
+- Conventional commits (`feat:`, `fix:`, etc.), one logical change per
+  commit.
+- Never commit broken code. If a commit would be broken, fold the fix in
+  before committing.
+
+## Step 6 — Run the test gate
+
+For each bullet in the issue's **Tests / validation** section, run the
+corresponding command. Report results in this block:
+
+```
+## Test Results
+
+- **cargo check**: ✅ | ❌
+- **cargo test <pattern>**: ✅ N passed | ❌ N failed
+- **<E2E or other workflow-driven test>**: ✅ | ❌ | ⏭ skipped (reason)
+
+### Issues found
+- <any, or "None">
+```
+
+If any gate fails, **fix it before opening the PR**. If a listed test
+cannot be run in this environment (e.g. needs a GPU CI), explicitly flag
+it as skipped and call out that the PR needs that check when CI runs.
+
+## Step 7 — Push + open PR
+
+```bash
+git push -u origin <branch-name>
+gh pr create --title "<conventional-commit-style>" --body "$(cat <<'EOF'
+## Summary
+
+<1–3 bullets — what changed and why>
+
+## Closes
+
+Closes #<N>
+
+## Exit criteria
+
+<checklist copied from the issue body, with items checked off>
+
+## Test plan
+
+<checklist from the issue's Tests/validation section, with results>
+
+## Follow-ups
+
+<list of out-of-scope things discovered, or "None">
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+## Step 8 — Report back
+
+```
+## Task Complete
+
+- **Issue**: #<N> — <title>
+- **Branch**: `<branch-name>`
+- **PR**: <url>
+- **Commits**: <n>
+- **Files changed**: <n>
+- **Lines**: +<added> / -<removed>
+
+### Tests run
+- <summary>
+
+### Follow-ups filed
+- <list, or "None">
+
+### Ready for review
+PR is open. Do NOT merge — merge is the user's call.
+```
+
+## Rules (non-negotiable)
+
+1. **One branch per issue.** Never mix work from multiple issues.
+2. **Never merge to main.** PRs only.
+3. **Never edit outside scope.** Note as follow-up.
+4. **Always announce and wait for confirmation** before branching.
+5. **Always run the test gate** before pushing.
+6. **Never ignore a label's workflow file** — if `.claude/workflows/<label>.md`
+   exists for a label on this issue, its instructions are mandatory for
+   this task.
+7. **Bank follow-ups as new issues** when the user asks — include the same
+   `Description / Context / Exit criteria / Tests / Related` template and
+   assign to a milestone.

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -1,32 +1,45 @@
-# Amos Frontmatter Specification v0.5
+# Amos Frontmatter Specification v0.6
 
 ## Overview
 
-Amos scans markdown files, finds `whoami: amos` blocks, builds a dependency DAG, and dumps the graph state to stdout. He reads the ship and reports what he sees.
+Amos scans markdown files, finds `whoami: amos` blocks, builds a typed-edge
+dependency graph, and reports what he sees. He reads the ship and reports
+what he finds — he does not own the underlying work items; GitHub (or other
+adapters) do.
 
-## Block Format
+## Block format
 
 ```yaml
 ---
 whoami: amos
 name: "@github:tatolab/myproject#42"
 description: Short routing hint — enough to know when this node is relevant
-dependencies:
-  - "up:@github:tatolab/myproject#41"
-  - "down:@github:tatolab/myproject#43"
+blocked_by:
+  - "@github:tatolab/myproject#41"
+blocks:
+  - "@github:tatolab/myproject#43"
+related_to:
+  - "@github:tatolab/otherproject#7"
+duplicates: "@github:tatolab/myproject#40"
+superseded_by: "@github:tatolab/myproject#99"
+labels: [refactor, gpu]
+priority: p2
 context:
   - path/to/relevant/file.rs
-  - @github:org/repo#path/to/file
+  - "@github:org/repo#path/to/file"
+adapters:
+  github: builtin
 ---
 
 @github:tatolab/myproject#42
 
-Agent-specific instructions, implementation notes, constraints.
-The @reference above lazily pulls the issue body at expansion time.
-Local content here supplements what the issue says.
+Agent-specific instructions, implementation notes, constraints. The
+`@reference` above lazily pulls the issue body at expansion time. Local
+content here supplements what the issue says.
 ```
 
-Each `.md` file contains at most one amos block, which must be the first frontmatter block in the file. Leading blank lines are allowed.
+Each `.md` file contains at most one amos block, which must be the first
+frontmatter block in the file. Leading blank lines are allowed.
 
 ## Fields
 
@@ -36,51 +49,103 @@ Must be `amos`. The discriminator — blocks without it are ignored.
 
 ### `name` (required)
 
-Unique node identifier. Can be a plain name (`my-feature`) or a URI (`@github:owner/repo#N`). URI-based names are self-documenting and portable — they work without amos installed.
+The stable identifier for this node. Use the adapter-qualified URI form
+whenever possible: `@github:owner/repo#N`. This:
+
+- Is self-documenting.
+- Survives external edits — GitHub can't rename an issue number.
+- Matches the adapter scheme used to resolve the body.
+
+**Do not put free-form descriptive text in `name`.** `name` is the edge-resolution
+key across the DAG. If another node has `blocked_by: [<this-name>]`, the
+match is string-equality; a renamed `name` silently breaks every referring
+edge. Use `amos rename <old> <new>` to change a name safely — it rewrites
+every reference in the scan tree.
 
 ### `description` (optional)
 
-A routing hint — tells agents and humans *when this node is relevant*, not what it contains. Think of it like a skill description: enough to decide "should I look at this?" without loading the full body.
+A routing hint — tells agents and humans *when this node is relevant*, not
+what it contains. Think of it like a skill description: enough to decide
+"should I look at this?" without loading the full body.
 
-Keep it short (one line). The actual content lives in the body, resolved lazily from `@` references.
+Keep it short (one line). The actual content lives in the body, resolved
+lazily from `@` references.
 
-### `dependencies` (optional)
+### Relationships
 
-- `up:<name>` — upstream dependency (must complete first)
-- `down:<name>` — downstream dependent (waits for this)
+Each relationship field is a distinct edge type in the DAG. Queries
+(`amos next`, `amos blocked`, `amos validate`) filter by kind.
 
-Both sides can declare the same edge. Duplicates are deduplicated.
+| Field             | Shape              | Meaning                                           | Mirror on target      |
+| ----------------- | ------------------ | ------------------------------------------------- | --------------------- |
+| `blocked_by`      | list of names      | These must complete before this one can start.    | `blocks`              |
+| `blocks`          | list of names      | These can't start until this one is done.         | `blocked_by`          |
+| `related_to`      | list of names      | Soft association — no ordering or gating.         | `related_to` (sym.)   |
+| `duplicates`      | single name        | This node duplicates another (target is canon.).  | —                     |
+| `superseded_by`   | single name        | This node has been replaced by the target.        | —                     |
+
+Declaring an edge from either side is sufficient — amos deduplicates. If
+both sides declare the same edge, it's still one edge.
+
+### Grouping
+
+There is intentionally no `parent:` / `children:` field. Grouping is
+delegated to **GitHub milestones**, resolved through the adapter. Amos
+displays milestone membership as a visual grouping in the tree and provides
+milestone-scoped queries, but the milestones themselves live in GitHub.
+
+### Attributes
+
+| Field       | Shape           | Example                                  |
+| ----------- | --------------- | ---------------------------------------- |
+| `labels`    | list of strings | `[refactor, gpu]`                        |
+| `priority`  | enum            | `p0` / `p1` / `p2` / `p3` (p0 = highest) |
+
+Status does **not** live in frontmatter — it belongs in `.amos-status` at
+the scan root. Rationale: keeping status out of the plan files avoids
+rewriting spec documents every time a ticket moves; diffs show status
+changes as a single line in one place; sync from external adapters is
+unambiguous about who owns the value.
 
 ### `context` (optional)
 
-- Bare path: local file relative to scan root
-- `@github:<owner/repo>[#<path>][@<ref>]`: GitHub reference
+Pointers to files or references relevant to understanding this node:
+
+- Bare path: local file relative to the scan root
+- `@github:<owner/repo>[#<path>][@<ref>]`: GitHub file reference
 - `@url:<url>`: arbitrary URL
 
-## Node Body
+## Node body
 
 The body (everything after the closing `---`) contains two kinds of content:
 
-1. **`@` references** — lines starting with `@scheme:reference` are lazily resolved through adapters when the node is expanded. They pull in external content (issue descriptions, file contents, images, video frames).
+1. **`@` references** — lines starting with `@scheme:reference` are lazily
+   resolved through adapters when the node is expanded. They pull in
+   external content (issue descriptions, file contents, images, video
+   frames).
 
-2. **Local content** — everything else. Agent-specific instructions, implementation constraints, notes that shouldn't live in the external system.
+2. **Local content** — everything else. Agent-specific instructions,
+   implementation constraints, notes that shouldn't live in the external
+   system.
 
-This separation means: the issue has the *what*, the local markdown has the *how-for-AI*.
+This separation means: the issue has the *what*, the local markdown has
+the *how-for-AI*.
 
 ### Built-in `@` reference schemes
 
-| Scheme | Example | Resolves to |
-|--------|---------|-------------|
-| `@github:` | `@github:tatolab/amos#11` | GitHub issue title + body |
-| `@file:` | `@file:src/main.rs` | File contents (text inline, images as paths) |
-| `@url:` | `@url:https://example.com/doc.md` | Downloaded content (images cached locally) |
-| `@ffmpeg:` | `@ffmpeg:recordings/bug.mp4` | Keyframes extracted as images |
+| Scheme     | Example                        | Resolves to                                   |
+| ---------- | ------------------------------ | --------------------------------------------- |
+| `@github:` | `@github:tatolab/amos#11`      | GitHub issue title + body                     |
+| `@file:`   | `@file:src/main.rs`            | File contents (text inline, images as paths)  |
+| `@url:`    | `@url:https://example.com/doc` | Downloaded content (images cached locally)    |
+| `@ffmpeg:` | `@ffmpeg:recordings/bug.mp4`   | Keyframes extracted as images                 |
 
 External adapters can be registered in `.amosrc.toml` for any scheme.
 
 ## Status
 
-Status is stored in `.amos-status` at the scan root, not in frontmatter. Node files are immutable specs.
+Status is stored in `.amos-status` at the scan root. Node files are
+immutable specs — they describe what should happen, not what has happened.
 
 ```
 - [x] @github:tatolab/amos#1
@@ -88,51 +153,67 @@ Status is stored in `.amos-status` at the scan root, not in frontmatter. Node fi
 - [ ] @github:tatolab/amos#16
 ```
 
-`[x]` = done, `[~]` = in-progress, `[ ]` or absent = not started.
+`[x]` = done, `[~]` = in-progress, `[ ]` or absent = pending.
 
-### Status Computation
+Status resolution:
 
-1. `.amos-status` says done → **done**
-2. `.amos-status` says in-progress → **in-progress**
-3. All upstream done → **ready**
-4. Any upstream not done → **blocked**
+1. If `.amos-status` says done → **done**.
+2. If `.amos-status` says in-progress → **in-progress**.
+3. Else: **pending**.
 
-### Syncing Status
-
-`amos sync` resolves URI-based node names through adapters and writes `.amos-status`. For `@github:` nodes, closed issues → done, open with "in-progress" label → in-progress.
+Future: `amos sync` will reconcile `.amos-status` with adapter state
+(closed GitHub issue → done, open + "in-progress" label → in-progress).
 
 ## CLI
 
 ```
-amos                    # scan cwd, print DAG state
-amos --dir /path        # scan specific directory
-amos done <node>        # mark node done in .amos-status
-amos start <node>       # mark node in-progress
-amos reset <node>       # clear node status
-amos sync               # sync status from external adapters
+amos                       # scan cwd, print the DAG summary
+amos --dir <path>          # override scan root
+amos graph                 # print the dependency tree as ASCII
+amos show <node>           # print a single node with its resolved body
+amos validate              # run DAG integrity checks (non-zero exit on errors)
+
+amos next                  # ready-to-start: all blockers done, not yet done
+amos blocked               # blocked: has at least one non-done blocker
+amos orphans               # no relationships of any kind
+
+amos done <node>           # mark node done in .amos-status
+amos start <node>          # mark node in-progress
+amos reset <node>          # clear node's .amos-status entry
+
+amos notify <node> <msg>   # send a message through the node's adapter
+amos rename <old> <new>    # rename a node, rewriting every reference
+amos migrate [--dry-run]   # convert legacy frontmatter to the typed model
 ```
 
-Output goes to stdout. Status messages go to stderr.
+Output goes to stdout. Status messages (informational) go to stderr.
+`--dry-run` is available on commands that mutate files (`migrate`, `rename`).
 
 ## Discovery
 
-Scans all `.md` files under scan root, respecting `.gitignore`. `.git` is skipped.
+Scans all `.md` files under scan root, respecting `.gitignore`. `.git` is
+skipped.
 
 ## Output
 
-The DAG state is printed as structured markdown:
+The default `amos` output is structured markdown:
 
-- **DAG section** — one line per node: name (linkified for `@github:`), status, description, dependencies
-- **Execution order** — topologically sorted remaining work
-- **Critical path** — longest dependency chain
-- **Ready / In-Progress** — expanded detail with lazily resolved body for actionable nodes
-- **Issues** — validation problems (cycles, missing dependencies)
+- **Issues** — validation problems (cycles, missing dependencies).
+- **DAG summary** — one line per node: name, adapter facts, description.
+- **Topological Order** — `node-a → node-b → node-c`.
+- **Critical Path** — longest blocker chain.
+- **Detail** — for each node with a body, the resolved content with
+  `@` references expanded through adapters.
 
-Compact for done/blocked nodes (one line). Expanded for ready/in-progress (full body with `@` references resolved).
+The `amos graph` output is the DAG as an ASCII tree. Children are ordered
+by the parent's declared `blocks:` list (authoring order), with any extras
+appended sorted numerically so `#99` comes before `#100`. `(→ see above)`
+back-references prevent re-printing a subtree twice.
 
 ## Adapters
 
-Adapters resolve URI schemes. Built-in adapters are always available. External adapters are registered in `.amosrc.toml`:
+Adapters resolve URI schemes. Built-in adapters are always available.
+External adapters are registered in `.amosrc.toml`:
 
 ```toml
 [adapters.jira]
@@ -140,17 +221,35 @@ command = "npx @openclaw/amos-adapter-jira"
 ```
 
 External adapters are any executable that speaks the protocol:
+
 ```
 <command> resolve <reference>  → JSON to stdout
 <command> batch <json-array>   → JSON object keyed by reference
 ```
 
 JSON shape:
+
 ```json
 {
   "name": "optional string",
   "description": "optional string",
   "status": "done | in-progress | null",
-  "body": "optional string"
+  "body": "optional string",
+  "facts": { "state": "open", "labels": "..." }
 }
 ```
+
+## Migration from legacy format
+
+Amos previously used a single `dependencies:` list with `up:`/`down:`
+prefixes and an in-frontmatter `status:` field. Both are gone. The parser
+errors on either, pointing to `amos migrate`.
+
+`amos migrate` does literal conversion:
+
+- `up:X` → `blocked_by: [X]`
+- `down:X` → `blocks: [X]`
+- `status: <value>` → removed from frontmatter; non-pending values move to
+  `.amos-status`.
+
+No heuristics, no interpretive logic. Grouping stays in GitHub milestones.

--- a/src/amosrc.rs
+++ b/src/amosrc.rs
@@ -1,0 +1,109 @@
+//! `.amosrc.toml` read/write.
+//!
+//! Small config file stored at the scan root. Today it holds only two things:
+//!
+//! - `[adapters]` tables (existing) — external adapter command registrations.
+//! - `focus` (new) — the milestone the user is currently working on. Used by
+//!   `amos next`, `amos blocked`, `amos orphans`, and future milestone-aware
+//!   queries to scope their results.
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub const AMOSRC_FILENAME: &str = ".amosrc.toml";
+
+pub fn path(scan_root: &Path) -> PathBuf {
+    scan_root.join(AMOSRC_FILENAME)
+}
+
+/// Read the focused milestone if set.
+pub fn read_focus(scan_root: &Path) -> Result<Option<String>> {
+    let p = path(scan_root);
+    if !p.exists() {
+        return Ok(None);
+    }
+    let content = fs::read_to_string(&p)
+        .with_context(|| format!("reading {}", p.display()))?;
+    let table: toml::Table = content
+        .parse()
+        .with_context(|| format!("parsing {}", p.display()))?;
+    Ok(table.get("focus").and_then(|v| v.as_str()).map(String::from))
+}
+
+/// Set (or clear) the focused milestone, preserving other fields in the file.
+pub fn write_focus(scan_root: &Path, focus: Option<&str>) -> Result<()> {
+    let p = path(scan_root);
+    let mut table: toml::Table = if p.exists() {
+        fs::read_to_string(&p)
+            .with_context(|| format!("reading {}", p.display()))?
+            .parse()
+            .with_context(|| format!("parsing {}", p.display()))?
+    } else {
+        toml::Table::new()
+    };
+
+    match focus {
+        Some(value) => {
+            table.insert("focus".to_string(), toml::Value::String(value.to_string()));
+        }
+        None => {
+            table.remove("focus");
+        }
+    }
+
+    if table.is_empty() {
+        if p.exists() {
+            fs::remove_file(&p)
+                .with_context(|| format!("removing empty {}", p.display()))?;
+        }
+    } else {
+        let serialized = toml::to_string(&table)
+            .context("serializing .amosrc.toml")?;
+        fs::write(&p, serialized)
+            .with_context(|| format!("writing {}", p.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn roundtrip_focus_value() {
+        let dir = tempdir().unwrap();
+        assert_eq!(read_focus(dir.path()).unwrap(), None);
+
+        write_focus(dir.path(), Some("GPU Capability Rewrite")).unwrap();
+        assert_eq!(
+            read_focus(dir.path()).unwrap(),
+            Some("GPU Capability Rewrite".to_string())
+        );
+
+        write_focus(dir.path(), None).unwrap();
+        assert_eq!(read_focus(dir.path()).unwrap(), None);
+    }
+
+    #[test]
+    fn preserves_other_fields() {
+        let dir = tempdir().unwrap();
+        let p = path(dir.path());
+        fs::write(
+            &p,
+            r#"
+[adapters.jira]
+command = "npx @openclaw/amos-adapter-jira"
+"#,
+        )
+        .unwrap();
+
+        write_focus(dir.path(), Some("Some Milestone")).unwrap();
+
+        let after = fs::read_to_string(&p).unwrap();
+        assert!(after.contains("focus = \"Some Milestone\""));
+        assert!(after.contains("[adapters.jira]"));
+        assert!(after.contains("npx @openclaw/amos-adapter-jira"));
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -32,4 +32,64 @@ pub enum Command {
         /// Node name (e.g. @github:tatolab/amos#22)
         node: String,
     },
+    /// Migrate legacy `dependencies: up:/down:` frontmatter to the typed
+    /// relationship model (`blocked_by:`/`blocks:`). Status fields move to
+    /// `.amos-status`. Grouping is intentionally not handled — it's delegated
+    /// to GitHub milestones, resolved through the adapter.
+    Migrate {
+        /// Show the summary without writing files or the status file.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Mark a node as done in `.amos-status`.
+    Done {
+        /// Node name (e.g. @github:tatolab/amos#22)
+        node: String,
+    },
+    /// Mark a node as in-progress in `.amos-status`.
+    Start {
+        /// Node name
+        node: String,
+    },
+    /// Clear a node's `.amos-status` entry (back to pending).
+    Reset {
+        /// Node name
+        node: String,
+    },
+    /// Run DAG integrity checks — missing deps, cycles, asymmetric edges.
+    /// Exits non-zero when errors are present.
+    Validate,
+    /// Print nodes that are ready to start — all blockers done, node itself
+    /// not yet done.
+    Next,
+    /// Print nodes that are blocked — have at least one non-done blocker.
+    Blocked,
+    /// Print nodes with no relationships at all — no blocks/blocked_by/related_to.
+    Orphans,
+    /// Set the focused milestone in `.amosrc.toml`. Subsequent `amos next`,
+    /// `amos blocked`, `amos orphans`, and `amos graph` calls scope their
+    /// results to this milestone. Pass `--clear` to remove the focus.
+    Focus {
+        /// Milestone title (must match the GitHub milestone exactly).
+        #[arg(conflicts_with = "clear")]
+        milestone: Option<String>,
+        /// Clear the current focus, returning to unfiltered behaviour.
+        #[arg(long)]
+        clear: bool,
+    },
+    /// List milestones for every focus-capable node in the scan, pulled from
+    /// the adapter. Useful when deciding what to `amos focus` on.
+    Milestones,
+    /// Rename a node and every reference to it across all scanned files.
+    /// Use this instead of hand-editing — stale references silently break DAG
+    /// edges because the string no longer matches.
+    Rename {
+        /// Current node name (full canonical form).
+        old_name: String,
+        /// New node name (full canonical form).
+        new_name: String,
+        /// Show the summary without writing files.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -7,13 +7,33 @@ use std::collections::HashMap;
 
 use crate::parser::Node;
 
+/// The kind of relationship an edge represents.
+///
+/// The DAG stores multiple concurrent relationship types. Queries filter by
+/// kind so blocker analyses can walk Blocks edges independently of associative
+/// markers like Related / Duplicates / Supersedes.
+///
+/// There is intentionally no hierarchical `Parent` edge — grouping is tied to
+/// GitHub milestones, not to a parallel notion in amos.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum EdgeKind {
+    /// Temporal: source blocks target (target waits on source).
+    Blocks,
+    /// Soft association; stored both directions to keep queries symmetric.
+    Related,
+    /// Source duplicates target (target is canonical).
+    Duplicates,
+    /// Source has been replaced by target.
+    Supersedes,
+}
+
 /// The dependency DAG built from parsed nodes.
 ///
-/// Pure data structure — stores the graph of nodes and edges.
+/// Pure data structure — stores the graph of nodes and typed edges.
 /// No status interpretation. Adapters provide facts on demand,
 /// the consuming agent reasons about them.
 pub struct Dag {
-    pub graph: DiGraph<Node, ()>,
+    pub graph: DiGraph<Node, EdgeKind>,
     pub name_to_index: HashMap<String, NodeIndex>,
 }
 
@@ -66,7 +86,7 @@ impl std::fmt::Display for DagIssue {
 impl Dag {
     /// Build a DAG from parsed nodes.
     pub fn build(nodes: Vec<Node>) -> Result<Self> {
-        let mut graph = DiGraph::new();
+        let mut graph: DiGraph<Node, EdgeKind> = DiGraph::new();
         let mut name_to_index: HashMap<String, NodeIndex> = HashMap::new();
 
         // Add all nodes first
@@ -83,34 +103,58 @@ impl Dag {
             name_to_index.insert(node.name.clone(), idx);
         }
 
-        // Add edges (deduplicated — both sides may declare the same relationship)
-        // Edge direction: upstream -> downstream (upstream must complete first)
-        // So if B has `up:A`, edge is A -> B
-        // If A has `down:B`, edge is also A -> B
-        let mut added_edges: std::collections::HashSet<(NodeIndex, NodeIndex)> =
+        // Deduplicate by (source, target, kind) — a node may be reachable by
+        // declaration from either side (e.g. parent declares `children: [B]`
+        // and B declares `parent: A`), but we only want one edge per relation.
+        let mut added_edges: std::collections::HashSet<(NodeIndex, NodeIndex, EdgeKind)> =
             std::collections::HashSet::new();
+
+        let mut add_edge = |graph: &mut DiGraph<Node, EdgeKind>,
+                            from: NodeIndex,
+                            to: NodeIndex,
+                            kind: EdgeKind| {
+            if added_edges.insert((from, to, kind)) {
+                graph.add_edge(from, to, kind);
+            }
+        };
 
         for node in &nodes {
             let node_idx = name_to_index[&node.name];
 
-            for upstream_name in &node.upstream {
-                if let Some(&upstream_idx) = name_to_index.get(upstream_name) {
-                    let edge = (upstream_idx, node_idx);
-                    if added_edges.insert(edge) {
-                        graph.add_edge(upstream_idx, node_idx, ());
-                    }
+            // --- Blocks edges: source blocks target ---
+            for blocker_name in &node.blocked_by {
+                if let Some(&blocker_idx) = name_to_index.get(blocker_name) {
+                    add_edge(&mut graph, blocker_idx, node_idx, EdgeKind::Blocks);
                 }
-                // Missing deps are handled in validate(), not here
+            }
+            for blocked_name in &node.blocks {
+                if let Some(&blocked_idx) = name_to_index.get(blocked_name) {
+                    add_edge(&mut graph, node_idx, blocked_idx, EdgeKind::Blocks);
+                }
             }
 
-            for downstream_name in &node.downstream {
-                if let Some(&downstream_idx) = name_to_index.get(downstream_name) {
-                    let edge = (node_idx, downstream_idx);
-                    if added_edges.insert(edge) {
-                        graph.add_edge(node_idx, downstream_idx, ());
-                    }
+            // --- Related: symmetric, stored both directions ---
+            for related_name in &node.related_to {
+                if let Some(&related_idx) = name_to_index.get(related_name) {
+                    add_edge(&mut graph, node_idx, related_idx, EdgeKind::Related);
+                    add_edge(&mut graph, related_idx, node_idx, EdgeKind::Related);
                 }
             }
+
+            // --- Duplicates: source duplicates target (target is canonical) ---
+            if let Some(dup_name) = &node.duplicates {
+                if let Some(&dup_idx) = name_to_index.get(dup_name) {
+                    add_edge(&mut graph, node_idx, dup_idx, EdgeKind::Duplicates);
+                }
+            }
+
+            // --- Supersedes: source has been replaced by target ---
+            if let Some(sup_name) = &node.superseded_by {
+                if let Some(&sup_idx) = name_to_index.get(sup_name) {
+                    add_edge(&mut graph, node_idx, sup_idx, EdgeKind::Supersedes);
+                }
+            }
+
         }
 
         Ok(Dag {
@@ -239,27 +283,23 @@ impl Dag {
             issues.push(DagIssue::CycleDetected);
         }
 
-        // Check for missing dependencies
+        // Check for missing dependencies across every typed relationship field.
         for idx in self.graph.node_indices() {
             let node = &self.graph[idx];
 
-            for dep in &node.upstream {
+            let mut check = |dep: &String| {
                 if !self.name_to_index.contains_key(dep) {
                     issues.push(DagIssue::MissingDependency {
                         from_node: node.name.clone(),
                         missing_dep: dep.clone(),
                     });
                 }
-            }
-
-            for dep in &node.downstream {
-                if !self.name_to_index.contains_key(dep) {
-                    issues.push(DagIssue::MissingDependency {
-                        from_node: node.name.clone(),
-                        missing_dep: dep.clone(),
-                    });
-                }
-            }
+            };
+            for dep in &node.blocked_by { check(dep); }
+            for dep in &node.blocks { check(dep); }
+            for dep in &node.related_to { check(dep); }
+            if let Some(dep) = &node.duplicates { check(dep); }
+            if let Some(dep) = &node.superseded_by { check(dep); }
 
             // Check local file context references
             for ctx in &node.context {
@@ -286,7 +326,7 @@ impl Dag {
             .collect()
     }
 
-    /// Get upstream neighbors of a node.
+    /// Get upstream neighbors across all edge kinds.
     pub fn upstream_of(&self, name: &str) -> Vec<&Node> {
         let Some(&idx) = self.name_to_index.get(name) else {
             return Vec::new();
@@ -297,7 +337,7 @@ impl Dag {
             .collect()
     }
 
-    /// Get downstream neighbors of a node.
+    /// Get downstream neighbors across all edge kinds.
     pub fn downstream_of(&self, name: &str) -> Vec<&Node> {
         let Some(&idx) = self.name_to_index.get(name) else {
             return Vec::new();
@@ -307,6 +347,59 @@ impl Dag {
             .map(|edge| &self.graph[edge.target()])
             .collect()
     }
+
+    /// Generic neighbor lookup: neighbors reachable via edges of `kind` in
+    /// `direction`. All kind-specific helpers below are thin wrappers.
+    fn neighbors_by_kind(
+        &self,
+        name: &str,
+        kind: EdgeKind,
+        direction: Direction,
+    ) -> Vec<&Node> {
+        let Some(&idx) = self.name_to_index.get(name) else {
+            return Vec::new();
+        };
+        self.graph
+            .edges_directed(idx, direction)
+            .filter(|edge| *edge.weight() == kind)
+            .map(|edge| {
+                let neighbor = match direction {
+                    Direction::Outgoing => edge.target(),
+                    Direction::Incoming => edge.source(),
+                };
+                &self.graph[neighbor]
+            })
+            .collect()
+    }
+
+    /// Nodes this node blocks (outgoing Blocks edges).
+    pub fn blocks_of(&self, name: &str) -> Vec<&Node> {
+        self.neighbors_by_kind(name, EdgeKind::Blocks, Direction::Outgoing)
+    }
+
+    /// Nodes blocking this node (incoming Blocks edges).
+    pub fn blocked_by_of(&self, name: &str) -> Vec<&Node> {
+        self.neighbors_by_kind(name, EdgeKind::Blocks, Direction::Incoming)
+    }
+
+    /// Nodes softly related to this one (outgoing Related edges; symmetric).
+    pub fn related_of(&self, name: &str) -> Vec<&Node> {
+        self.neighbors_by_kind(name, EdgeKind::Related, Direction::Outgoing)
+    }
+
+    /// Canonical node this one duplicates (outgoing Duplicates edge).
+    pub fn duplicates_of(&self, name: &str) -> Option<&Node> {
+        self.neighbors_by_kind(name, EdgeKind::Duplicates, Direction::Outgoing)
+            .into_iter()
+            .next()
+    }
+
+    /// Node that supersedes this one (outgoing Supersedes edge).
+    pub fn superseded_by_of(&self, name: &str) -> Option<&Node> {
+        self.neighbors_by_kind(name, EdgeKind::Supersedes, Direction::Outgoing)
+            .into_iter()
+            .next()
+    }
 }
 
 #[cfg(test)]
@@ -315,12 +408,17 @@ mod tests {
     use crate::parser::Node;
     use std::path::PathBuf;
 
-    fn make_node(name: &str, upstream: Vec<&str>, downstream: Vec<&str>) -> Node {
+    fn make_node(name: &str, blocked_by: Vec<&str>, blocks: Vec<&str>) -> Node {
         Node {
             name: name.to_string(),
             description: None,
-            upstream: upstream.into_iter().map(String::from).collect(),
-            downstream: downstream.into_iter().map(String::from).collect(),
+            blocked_by: blocked_by.into_iter().map(String::from).collect(),
+            blocks: blocks.into_iter().map(String::from).collect(),
+            related_to: Vec::new(),
+            duplicates: None,
+            superseded_by: None,
+            labels: Vec::new(),
+            priority: None,
             context: Vec::new(),
             adapters: std::collections::HashMap::new(),
             source_file: PathBuf::from("test.md"),
@@ -387,5 +485,57 @@ mod tests {
         let dag = Dag::build(nodes).unwrap();
         let issues = dag.validate(std::path::Path::new("/tmp"));
         assert!(issues.iter().any(|i| matches!(i, DagIssue::MissingDependency { .. })));
+    }
+
+    #[test]
+    fn test_blocks_edges() {
+        let mut a = make_node("a", vec![], vec![]);
+        a.blocks = vec!["b".to_string()];
+        let nodes = vec![a, make_node("b", vec![], vec![])];
+        let dag = Dag::build(nodes).unwrap();
+
+        assert_eq!(dag.blocks_of("a").len(), 1);
+        assert_eq!(dag.blocked_by_of("b").len(), 1);
+    }
+
+    #[test]
+    fn test_related_is_symmetric() {
+        let mut a = make_node("a", vec![], vec![]);
+        a.related_to = vec!["b".to_string()];
+        let nodes = vec![a, make_node("b", vec![], vec![])];
+        let dag = Dag::build(nodes).unwrap();
+
+        assert_eq!(dag.related_of("a").len(), 1);
+        assert_eq!(dag.related_of("b").len(), 1); // stored both directions
+    }
+
+    #[test]
+    fn test_duplicates_and_supersedes() {
+        let mut a = make_node("a", vec![], vec![]);
+        a.duplicates = Some("canonical".to_string());
+        let mut b = make_node("b", vec![], vec![]);
+        b.superseded_by = Some("new-version".to_string());
+        let nodes = vec![
+            a,
+            b,
+            make_node("canonical", vec![], vec![]),
+            make_node("new-version", vec![], vec![]),
+        ];
+        let dag = Dag::build(nodes).unwrap();
+
+        assert_eq!(dag.duplicates_of("a").map(|n| n.name.as_str()), Some("canonical"));
+        assert_eq!(dag.superseded_by_of("b").map(|n| n.name.as_str()), Some("new-version"));
+    }
+
+    #[test]
+    fn test_legacy_down_creates_blocks_edge() {
+        let nodes = vec![
+            make_node("a", vec![], vec!["b"]),
+            make_node("b", vec![], vec![]),
+        ];
+        let dag = Dag::build(nodes).unwrap();
+
+        assert_eq!(dag.blocks_of("a").len(), 1);
+        assert_eq!(dag.blocked_by_of("b").len(), 1);
     }
 }

--- a/src/gh_adapter.rs
+++ b/src/gh_adapter.rs
@@ -169,6 +169,108 @@ impl GhAdapter {
             return Ok(HashMap::new());
         }
 
+        // Single paginated API call — massively faster than N individual
+        // `gh issue view` calls. A scan over 80 issues goes from ~2 minutes
+        // to a couple of seconds. We fetch state=all so both open and
+        // closed issues land in the map; the caller filters as needed.
+        let repo_str = match repo.or(self.default_repo.as_deref()) {
+            Some(r) => r.to_string(),
+            None => return self.fetch_issues_batch_sequential(repo, numbers),
+        };
+
+        let mut cmd = Command::new("gh");
+        cmd.args([
+            "api",
+            "--paginate",
+            "-H",
+            "Accept: application/vnd.github+json",
+            &format!("repos/{}/issues?state=all&per_page=100", repo_str),
+        ]);
+        let output = match cmd.output() {
+            Ok(o) if o.status.success() => o,
+            _ => {
+                return self.fetch_issues_batch_sequential(repo, numbers);
+            }
+        };
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let issues = parse_issue_pages(&stdout).unwrap_or_default();
+
+        let wanted: std::collections::HashSet<u64> = numbers.iter().copied().collect();
+        let mut results = HashMap::new();
+        for entry in issues {
+            let Some(number) = entry.get("number").and_then(|v| v.as_u64()) else { continue };
+            if !wanted.contains(&number) {
+                continue;
+            }
+            if entry.get("pull_request").is_some() {
+                continue;
+            }
+
+            let title = entry
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let body = entry
+                .get("body")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let state = entry
+                .get("state")
+                .and_then(|v| v.as_str())
+                .unwrap_or("OPEN")
+                .to_uppercase();
+            let labels = entry
+                .get("labels")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|l| l.get("name").and_then(|v| v.as_str()).map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let milestone = entry
+                .get("milestone")
+                .and_then(|m| m.get("title"))
+                .and_then(|v| v.as_str())
+                .map(String::from);
+
+            results.insert(
+                number,
+                IssueData {
+                    title,
+                    body,
+                    state,
+                    labels,
+                    comments: Vec::new(),
+                    milestone,
+                },
+            );
+        }
+
+        // Anything not found in the bulk response falls back to per-issue
+        // fetch.
+        let missing: Vec<u64> = numbers
+            .iter()
+            .copied()
+            .filter(|n| !results.contains_key(n))
+            .collect();
+        if !missing.is_empty() {
+            let extra = self.fetch_issues_batch_sequential(repo, &missing)?;
+            results.extend(extra);
+        }
+
+        Ok(results)
+    }
+
+    /// Original per-issue loop, kept as the fallback path.
+    fn fetch_issues_batch_sequential(
+        &self,
+        repo: Option<&str>,
+        numbers: &[u64],
+    ) -> Result<HashMap<u64, IssueData>> {
         let mut results = HashMap::new();
         for &num in numbers {
             match self.fetch_issue(repo, num) {
@@ -182,6 +284,31 @@ impl GhAdapter {
         }
         Ok(results)
     }
+}
+
+/// Parse the concatenated JSON that `gh api --paginate` emits. Normally a
+/// single top-level array; for multi-page results, potentially multiple arrays
+/// concatenated. Handles both shapes.
+fn parse_issue_pages(text: &str) -> Option<Vec<serde_json::Value>> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return Some(Vec::new());
+    }
+
+    if let Ok(serde_json::Value::Array(arr)) = serde_json::from_str::<serde_json::Value>(trimmed) {
+        return Some(arr);
+    }
+
+    let mut out = Vec::new();
+    let de = serde_json::Deserializer::from_str(trimmed).into_iter::<serde_json::Value>();
+    for next in de {
+        match next {
+            Ok(serde_json::Value::Array(arr)) => out.extend(arr),
+            Ok(other) => out.push(other),
+            Err(_) => return None,
+        }
+    }
+    Some(out)
 }
 
 struct Comment {

--- a/src/gh_adapter.rs
+++ b/src/gh_adapter.rs
@@ -40,7 +40,7 @@ impl GhAdapter {
     fn fetch_issue(&self, repo: Option<&str>, number: u64) -> Result<IssueData> {
         let mut cmd = Command::new("gh");
         cmd.args(["issue", "view", &number.to_string()]);
-        cmd.args(["--json", "title,body,state,labels,comments"]);
+        cmd.args(["--json", "title,body,state,labels,comments,milestone"]);
 
         if let Some(r) = repo {
             cmd.args(["--repo", r]);
@@ -79,6 +79,8 @@ impl GhAdapter {
             })
             .unwrap_or_default();
 
+        let milestone = json["milestone"]["title"].as_str().map(String::from);
+
         Ok(IssueData {
             title: json["title"].as_str().unwrap_or("").to_string(),
             body: json["body"].as_str().unwrap_or("").to_string(),
@@ -92,6 +94,7 @@ impl GhAdapter {
                 })
                 .unwrap_or_default(),
             comments,
+            milestone,
         })
     }
 
@@ -193,6 +196,7 @@ struct IssueData {
     state: String,
     labels: Vec<String>,
     comments: Vec<Comment>,
+    milestone: Option<String>,
 }
 
 impl IssueData {
@@ -202,6 +206,9 @@ impl IssueData {
         facts.insert("state".to_string(), self.state.clone());
         if !self.labels.is_empty() {
             facts.insert("labels".to_string(), self.labels.join(", "));
+        }
+        if let Some(ms) = &self.milestone {
+            facts.insert("milestone".to_string(), ms.clone());
         }
         facts
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,18 @@
 pub mod adapter;
 pub mod adapter_pull;
+pub mod amosrc;
 pub mod cli;
 pub mod dag;
 pub mod external_adapter;
 pub mod ffmpeg_adapter;
 pub mod file_adapter;
 pub mod gh_adapter;
+pub mod migrate;
 pub mod output;
 pub mod parser;
+pub mod rename;
 pub mod resolver;
 pub mod scanner;
+pub mod status;
 
 pub mod url_adapter;

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,71 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
+    // Handle migrate command (runs before parsing into nodes — works on
+    // legacy frontmatter that the parser might not accept cleanly).
+    if let Some(Command::Migrate { dry_run }) = &cli.command {
+        let report = amos::migrate::migrate_tree(&scan_root, *dry_run)
+            .context("running migrate")?;
+        print_migration_report(&report, *dry_run);
+        return Ok(());
+    }
+
+    // Handle rename command. Runs on raw files — doesn't require parse.
+    if let Some(Command::Rename { old_name, new_name, dry_run }) = &cli.command {
+        let report = amos::rename::rename_tree(&scan_root, old_name, new_name, *dry_run)
+            .context("running rename")?;
+        if *dry_run {
+            println!("# Rename dry-run (no files written)");
+        } else {
+            println!("# Rename report");
+        }
+        println!();
+        println!("{}", report.summary());
+        return Ok(());
+    }
+
+    // Status-mutation commands operate on `.amos-status` directly and don't
+    // need a full scan/parse.
+    match &cli.command {
+        Some(Command::Done { node }) => {
+            let mut sf = amos::status::StatusFile::load(&scan_root)?;
+            sf.set(node, amos::status::Status::Done);
+            sf.save()?;
+            eprintln!("amos: marked '{}' done", node);
+            return Ok(());
+        }
+        Some(Command::Start { node }) => {
+            let mut sf = amos::status::StatusFile::load(&scan_root)?;
+            sf.set(node, amos::status::Status::InProgress);
+            sf.save()?;
+            eprintln!("amos: marked '{}' in-progress", node);
+            return Ok(());
+        }
+        Some(Command::Reset { node }) => {
+            let mut sf = amos::status::StatusFile::load(&scan_root)?;
+            sf.remove(node);
+            sf.save()?;
+            eprintln!("amos: reset '{}' to pending", node);
+            return Ok(());
+        }
+        Some(Command::Focus { milestone, clear }) => {
+            if *clear {
+                amos::amosrc::write_focus(&scan_root, None)?;
+                eprintln!("amos: cleared focused milestone");
+            } else if let Some(m) = milestone {
+                amos::amosrc::write_focus(&scan_root, Some(m))?;
+                eprintln!("amos: focused on milestone '{}'", m);
+            } else {
+                match amos::amosrc::read_focus(&scan_root)? {
+                    Some(m) => println!("{}", m),
+                    None => eprintln!("amos: no milestone currently focused"),
+                }
+            }
+            return Ok(());
+        }
+        _ => {}
+    }
+
     // Scan + parse
     let blocks = scanner::scan_directory(&scan_root)
         .with_context(|| format!("scanning {}", scan_root.display()))?;
@@ -52,13 +117,212 @@ fn main() -> Result<()> {
 
     // Handle graph command
     if matches!(&cli.command, Some(Command::Graph)) {
-        print!("{}", output::format_graph(&dag, &registry));
+        print!("{}", output::format_graph(&dag, &registry, &scan_root));
         return Ok(());
     }
 
     // Handle show command
     if let Some(Command::Show { node }) = &cli.command {
         print!("{}", output::format_node(&dag, node, &registry));
+        return Ok(());
+    }
+
+    // Handle validate command
+    if matches!(&cli.command, Some(Command::Validate)) {
+        let issues = dag.validate(&scan_root);
+        if issues.is_empty() {
+            eprintln!("amos: DAG clean — {} nodes, no issues", dag.all_nodes().len());
+            return Ok(());
+        }
+        println!("## Issues");
+        println!();
+        for issue in &issues {
+            println!("- {}", issue);
+        }
+        std::process::exit(1);
+    }
+
+    // Filter commands (next / blocked / orphans). All load the status file
+    // so blocker completeness is computed against the user's local state.
+    if matches!(
+        &cli.command,
+        Some(Command::Next) | Some(Command::Blocked) | Some(Command::Orphans)
+    ) {
+        let status_file = amos::status::StatusFile::load(&scan_root)?;
+        let is_done = |name: &str| {
+            status_file.get(name) == amos::status::Status::Done
+        };
+
+        // If a milestone is focused, pull adapter facts so we can scope
+        // results to that milestone. Adapter state (closed/milestone) takes
+        // precedence over .amos-status because the latter can drift.
+        let focus = amos::amosrc::read_focus(&scan_root)?;
+        let adapter_facts: std::collections::HashMap<String, amos::adapter::ResourceFields> =
+            if focus.is_some() {
+                let names: Vec<&str> = dag
+                    .all_nodes()
+                    .iter()
+                    .filter(|n| registry.is_resolvable(&n.name))
+                    .map(|n| n.name.as_str())
+                    .collect();
+                registry.resolve_batch(&names).unwrap_or_default()
+            } else {
+                std::collections::HashMap::new()
+            };
+        let in_focused_milestone = |name: &str| -> bool {
+            let Some(ref focused) = focus else { return true };
+            match adapter_facts.get(name) {
+                Some(fields) => fields
+                    .facts
+                    .get("milestone")
+                    .map(|m| m == focused)
+                    .unwrap_or(false),
+                None => false,
+            }
+        };
+        let adapter_closed = |name: &str| -> bool {
+            adapter_facts
+                .get(name)
+                .and_then(|f| f.facts.get("state"))
+                .map(|s| s.eq_ignore_ascii_case("CLOSED"))
+                .unwrap_or(false)
+        };
+
+        let mut matching: Vec<&amos::parser::Node> = Vec::new();
+        for node in dag.all_nodes() {
+            if !in_focused_milestone(&node.name) {
+                continue;
+            }
+            // Trust adapter state over .amos-status when available.
+            if adapter_closed(&node.name) {
+                continue;
+            }
+            match &cli.command {
+                Some(Command::Next) => {
+                    if is_done(&node.name) {
+                        continue;
+                    }
+                    let blockers = dag.blocked_by_of(&node.name);
+                    let all_satisfied = blockers.iter().all(|b| {
+                        is_done(&b.name) || adapter_closed(&b.name)
+                    });
+                    if all_satisfied {
+                        matching.push(node);
+                    }
+                }
+                Some(Command::Blocked) => {
+                    if is_done(&node.name) {
+                        continue;
+                    }
+                    let blockers = dag.blocked_by_of(&node.name);
+                    let any_open = blockers.iter().any(|b| {
+                        !is_done(&b.name) && !adapter_closed(&b.name)
+                    });
+                    if any_open {
+                        matching.push(node);
+                    }
+                }
+                Some(Command::Orphans) => {
+                    if dag.blocked_by_of(&node.name).is_empty()
+                        && dag.blocks_of(&node.name).is_empty()
+                        && dag.related_of(&node.name).is_empty()
+                    {
+                        matching.push(node);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        matching.sort_by(|a, b| {
+            amos::output::numeric_aware_cmp(&a.name, &b.name)
+        });
+        for node in &matching {
+            let desc = node.description.as_deref().unwrap_or("");
+            if desc.is_empty() {
+                println!("- {}", node.name);
+            } else {
+                println!("- {} — {}", node.name, desc);
+            }
+        }
+        if matching.is_empty() {
+            if let Some(ref f) = focus {
+                eprintln!("amos: no matching nodes in focused milestone '{}'", f);
+            } else {
+                eprintln!("amos: no matching nodes");
+            }
+        }
+        return Ok(());
+    }
+
+    // Milestones listing — per-milestone open/closed/ready counts pulled from
+    // the adapter. "Ready" means an open node whose blocked_by set is fully
+    // done (via .amos-status) or closed (via adapter state).
+    if matches!(&cli.command, Some(Command::Milestones)) {
+        let names: Vec<&str> = dag
+            .all_nodes()
+            .iter()
+            .filter(|n| registry.is_resolvable(&n.name))
+            .map(|n| n.name.as_str())
+            .collect();
+        let adapter_facts = registry.resolve_batch(&names).unwrap_or_default();
+        let status_file = amos::status::StatusFile::load(&scan_root)?;
+        let current_focus = amos::amosrc::read_focus(&scan_root)?;
+
+        let is_closed = |node_name: &str| -> bool {
+            adapter_facts
+                .get(node_name)
+                .and_then(|f| f.facts.get("state"))
+                .map(|s| s.eq_ignore_ascii_case("CLOSED"))
+                .unwrap_or(false)
+        };
+        let is_done_or_closed = |node_name: &str| -> bool {
+            if is_closed(node_name) {
+                return true;
+            }
+            status_file.get(node_name) == amos::status::Status::Done
+        };
+
+        // title -> (open, closed, ready)
+        let mut milestone_counts: std::collections::BTreeMap<String, (usize, usize, usize)> =
+            std::collections::BTreeMap::new();
+        for (node_name, fields) in adapter_facts.iter() {
+            let Some(ms) = fields.facts.get("milestone") else { continue };
+            let state = fields
+                .facts
+                .get("state")
+                .map(|s| s.as_str())
+                .unwrap_or("OPEN");
+            let entry = milestone_counts.entry(ms.clone()).or_default();
+            if state.eq_ignore_ascii_case("CLOSED") {
+                entry.1 += 1;
+                continue;
+            }
+            entry.0 += 1;
+            // Ready = all blockers satisfied.
+            let blockers = dag.blocked_by_of(node_name);
+            let all_satisfied = blockers.iter().all(|b| is_done_or_closed(&b.name));
+            if all_satisfied {
+                entry.2 += 1;
+            }
+        }
+        if milestone_counts.is_empty() {
+            eprintln!("amos: no milestones found in adapter data");
+            return Ok(());
+        }
+        println!("{:2}{:50}  {:>6}  {:>6}  {:>6}", "", "milestone", "open", "ready", "done");
+        for (title, (open, closed, ready)) in milestone_counts {
+            let marker = if current_focus.as_deref() == Some(title.as_str()) {
+                "* "
+            } else {
+                "  "
+            };
+            let label = format!("\"{}\"", title);
+            println!(
+                "{}{:50}  {:>6}  {:>6}  {:>6}",
+                marker, label, open, ready, closed
+            );
+        }
         return Ok(());
     }
 
@@ -107,6 +371,48 @@ fn build_registry(scan_root: &std::path::Path, nodes: &[amos::parser::Node]) -> 
     }
 
     registry
+}
+
+/// Print a human-readable summary of a migration run.
+fn print_migration_report(report: &amos::migrate::MigrationReport, dry_run: bool) {
+    use amos::migrate::FileChange;
+
+    if dry_run {
+        println!("# Migration dry-run (no files written)");
+    } else {
+        println!("# Migration report");
+    }
+    println!();
+    println!("{}", report.summary());
+    println!();
+
+    let mut migrated: Vec<&amos::migrate::FileReport> = report
+        .files
+        .iter()
+        .filter(|r| r.kind == FileChange::Migrated)
+        .collect();
+    migrated.sort_by(|a, b| a.path.cmp(&b.path));
+
+    if migrated.is_empty() {
+        println!("No files needed migration.");
+        return;
+    }
+
+    println!("## Files migrated");
+    println!();
+    for r in &migrated {
+        let status_note = match r.status_moved {
+            Some(s) => format!(" status→.amos-status({:?})", s),
+            None => String::new(),
+        };
+        println!(
+            "- {}  (+{} blocked_by, +{} blocks{})",
+            r.path.display(),
+            r.blocked_by_added,
+            r.blocks_added,
+            status_note
+        );
+    }
 }
 
 /// Build a minimal registry with just built-in adapters.

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -1,0 +1,452 @@
+//! One-shot migration from the legacy frontmatter format to the typed model.
+//!
+//! Legacy frontmatter used a single `dependencies:` list with `up:`/`down:`
+//! prefixes and an in-frontmatter `status:` field. This module converts it:
+//!
+//! - `up:X` entries become `blocked_by: [X]`.
+//! - `down:X` entries become `blocks: [X]`.
+//! - `status: <value>` is stripped from frontmatter and written to
+//!   `.amos-status` when the value is `in-progress`/`in_progress` or
+//!   `completed`/`done`. `pending` (or absent) is the default and produces no
+//!   entry.
+//!
+//! Grouping ("umbrellas") is intentionally not handled here — that concept is
+//! delegated to GitHub milestones, resolved through the adapter in a separate
+//! feature. The migration produces a flat DAG of typed-edge relationships.
+//!
+//! With `dry_run`, no files are written; a [`MigrationReport`] describing what
+//! would change is still returned so callers can surface the diff summary.
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::status::{Status, StatusFile};
+
+/// Per-file migration result.
+#[derive(Debug, Clone)]
+pub struct FileReport {
+    pub path: PathBuf,
+    pub kind: FileChange,
+    pub blocked_by_added: usize,
+    pub blocks_added: usize,
+    pub status_moved: Option<Status>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileChange {
+    /// The file had legacy fields and was (or would be) rewritten.
+    Migrated,
+    /// Already in the new format — no changes needed.
+    Unchanged,
+    /// Not an amos block; skipped.
+    NotAmos,
+}
+
+#[derive(Debug, Default)]
+pub struct MigrationReport {
+    pub files: Vec<FileReport>,
+    pub status_file_entries: usize,
+}
+
+impl MigrationReport {
+    pub fn migrated_files(&self) -> impl Iterator<Item = &FileReport> {
+        self.files.iter().filter(|r| r.kind == FileChange::Migrated)
+    }
+
+    pub fn summary(&self) -> String {
+        let migrated: Vec<&FileReport> = self.migrated_files().collect();
+        let total_edges: usize = migrated
+            .iter()
+            .map(|r| r.blocked_by_added + r.blocks_added)
+            .sum();
+        format!(
+            "{} files migrated, {} edges converted, {} status entries",
+            migrated.len(),
+            total_edges,
+            self.status_file_entries
+        )
+    }
+}
+
+/// Migrate every markdown file under `scan_root`. Status entries accumulate
+/// into a StatusFile that is written (or skipped, on dry_run) at the end.
+pub fn migrate_tree(scan_root: &Path, dry_run: bool) -> Result<MigrationReport> {
+    let mut report = MigrationReport::default();
+    let mut status_file = StatusFile::load(scan_root)?;
+    let initial_status_len = status_file.len();
+
+    // Walk all .md files under scan_root.
+    let walker = ignore::WalkBuilder::new(scan_root)
+        .standard_filters(true)
+        .build();
+
+    for entry in walker.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if path.extension().and_then(|s| s.to_str()) != Some("md") {
+            continue;
+        }
+        let file_report = migrate_file(path, &mut status_file, dry_run)?;
+        report.files.push(file_report);
+    }
+
+    if !dry_run {
+        status_file.save()?;
+    }
+    report.status_file_entries = status_file.len().saturating_sub(initial_status_len);
+
+    Ok(report)
+}
+
+/// Migrate a single file. On dry_run, computes the change without writing.
+pub fn migrate_file(
+    path: &Path,
+    status_file: &mut StatusFile,
+    dry_run: bool,
+) -> Result<FileReport> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("reading {}", path.display()))?;
+
+    let Some((fm_str, body)) = split_frontmatter(&content) else {
+        return Ok(FileReport {
+            path: path.to_path_buf(),
+            kind: FileChange::NotAmos,
+            blocked_by_added: 0,
+            blocks_added: 0,
+            status_moved: None,
+        });
+    };
+
+    let mut fm: serde_yaml::Value = serde_yaml::from_str(fm_str)
+        .with_context(|| format!("parsing frontmatter YAML in {}", path.display()))?;
+
+    // Only operate on amos blocks.
+    if fm.get("whoami").and_then(|v| v.as_str()) != Some("amos") {
+        return Ok(FileReport {
+            path: path.to_path_buf(),
+            kind: FileChange::NotAmos,
+            blocked_by_added: 0,
+            blocks_added: 0,
+            status_moved: None,
+        });
+    }
+
+    // Collect legacy dependencies.
+    let deps = fm
+        .get("dependencies")
+        .and_then(|v| v.as_sequence())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut new_blocked_by: Vec<String> = Vec::new();
+    let mut new_blocks: Vec<String> = Vec::new();
+
+    for dep in &deps {
+        let Some(s) = dep.as_str() else { continue };
+        if let Some(target) = s.strip_prefix("up:") {
+            new_blocked_by.push(target.trim().to_string());
+        } else if let Some(target) = s.strip_prefix("down:") {
+            new_blocks.push(target.trim().to_string());
+        }
+    }
+
+    // Status field.
+    let old_status_raw = fm.get("status").and_then(|v| v.as_str()).map(String::from);
+    let status_moved = match old_status_raw.as_deref() {
+        Some("done") | Some("completed") => Some(Status::Done),
+        Some("in-progress") | Some("in_progress") => Some(Status::InProgress),
+        _ => None, // "pending", empty, or absent — default
+    };
+
+    // Nothing to migrate if there are no legacy fields.
+    let has_legacy_fields = !deps.is_empty() || old_status_raw.is_some();
+    if !has_legacy_fields {
+        return Ok(FileReport {
+            path: path.to_path_buf(),
+            kind: FileChange::Unchanged,
+            blocked_by_added: 0,
+            blocks_added: 0,
+            status_moved: None,
+        });
+    }
+
+    let name = fm
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let blocked_by_added = new_blocked_by.len();
+    let blocks_added = new_blocks.len();
+
+    if let Some(fm_map) = fm.as_mapping_mut() {
+        fm_map.remove("dependencies");
+        fm_map.remove("status");
+
+        if !new_blocked_by.is_empty() {
+            merge_into_list(fm_map, "blocked_by", &new_blocked_by);
+        }
+        if !new_blocks.is_empty() {
+            merge_into_list(fm_map, "blocks", &new_blocks);
+        }
+    }
+
+    if !dry_run {
+        let new_fm_str = serde_yaml::to_string(&fm)
+            .with_context(|| format!("serializing migrated frontmatter for {}", path.display()))?;
+        let new_content = format!("---\n{}---\n{}", new_fm_str, body);
+        fs::write(path, new_content)
+            .with_context(|| format!("writing migrated {}", path.display()))?;
+    }
+
+    if let Some(status) = status_moved {
+        if !name.is_empty() {
+            status_file.set(&name, status);
+        }
+    }
+
+    Ok(FileReport {
+        path: path.to_path_buf(),
+        kind: FileChange::Migrated,
+        blocked_by_added,
+        blocks_added,
+        status_moved,
+    })
+}
+
+fn merge_into_list(
+    map: &mut serde_yaml::Mapping,
+    key: &str,
+    new_values: &[String],
+) {
+    let existing = map
+        .get(key)
+        .and_then(|v| v.as_sequence())
+        .cloned()
+        .unwrap_or_default();
+    let mut combined: Vec<serde_yaml::Value> = existing;
+    for v in new_values {
+        combined.push(serde_yaml::Value::String(v.clone()));
+    }
+    map.insert(
+        serde_yaml::Value::String(key.to_string()),
+        serde_yaml::Value::Sequence(combined),
+    );
+}
+
+/// Split a markdown file into (frontmatter_body, rest_of_file). Returns None
+/// if there's no leading frontmatter block.
+fn split_frontmatter(content: &str) -> Option<(&str, &str)> {
+    // Allow leading blank lines before the opening ---.
+    let trimmed_start = content.trim_start_matches(|c: char| c == '\n' || c == '\r');
+
+    if !trimmed_start.starts_with("---\n") && !trimmed_start.starts_with("---\r\n") {
+        return None;
+    }
+    let after_open = trimmed_start.strip_prefix("---\n").or_else(|| trimmed_start.strip_prefix("---\r\n"))?;
+
+    // Find closing --- on its own line.
+    let mut offset = 0;
+    for line in after_open.split_inclusive('\n') {
+        let line_trim = line.trim_end_matches(['\n', '\r']);
+        if line_trim == "---" {
+            let fm = &after_open[..offset];
+            let rest = &after_open[offset + line.len()..];
+            return Some((fm, rest));
+        }
+        offset += line.len();
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn write_md(dir: &Path, name: &str, content: &str) -> PathBuf {
+        let p = dir.join(name);
+        fs::write(&p, content).unwrap();
+        p
+    }
+
+    #[test]
+    fn migrate_non_umbrella_converts_down_to_blocks() {
+        let dir = tempdir().unwrap();
+        let path = write_md(
+            dir.path(),
+            "a.md",
+            r#"---
+whoami: amos
+name: task-a
+description: simple task
+dependencies:
+  - up:upstream-task
+  - down:downstream-task
+---
+
+body content
+"#,
+        );
+
+        let mut sf = StatusFile::load(dir.path()).unwrap();
+        let report = migrate_file(&path, &mut sf, false).unwrap();
+        assert_eq!(report.kind, FileChange::Migrated);
+        assert_eq!(report.blocked_by_added, 1);
+        assert_eq!(report.blocks_added, 1);
+
+        let after = fs::read_to_string(&path).unwrap();
+        assert!(after.contains("blocked_by:"));
+        assert!(after.contains("blocks:"));
+        assert!(!after.contains("dependencies:"));
+        assert!(!after.contains("up:"));
+        assert!(!after.contains("down:"));
+        assert!(after.contains("body content")); // body preserved
+    }
+
+    #[test]
+    fn migrate_status_in_frontmatter_moves_to_status_file() {
+        let dir = tempdir().unwrap();
+        let path = write_md(
+            dir.path(),
+            "a.md",
+            r#"---
+whoami: amos
+name: task-a
+status: in-progress
+description: "task in flight"
+---
+
+body
+"#,
+        );
+
+        let mut sf = StatusFile::load(dir.path()).unwrap();
+        let report = migrate_file(&path, &mut sf, false).unwrap();
+        assert_eq!(report.kind, FileChange::Migrated);
+        assert_eq!(report.status_moved, Some(Status::InProgress));
+
+        // Frontmatter no longer has status.
+        let after = fs::read_to_string(&path).unwrap();
+        assert!(!after.contains("status:"));
+        assert_eq!(sf.get("task-a"), Status::InProgress);
+    }
+
+    #[test]
+    fn migrate_pending_status_drops_without_status_entry() {
+        let dir = tempdir().unwrap();
+        let path = write_md(
+            dir.path(),
+            "a.md",
+            r#"---
+whoami: amos
+name: task-a
+status: pending
+---
+
+body
+"#,
+        );
+
+        let mut sf = StatusFile::load(dir.path()).unwrap();
+        let report = migrate_file(&path, &mut sf, false).unwrap();
+        assert_eq!(report.kind, FileChange::Migrated);
+        assert_eq!(report.status_moved, None);
+        assert_eq!(sf.len(), 0);
+    }
+
+    #[test]
+    fn migrate_already_migrated_file_is_unchanged() {
+        let dir = tempdir().unwrap();
+        let path = write_md(
+            dir.path(),
+            "a.md",
+            r#"---
+whoami: amos
+name: task-a
+description: "modern format"
+blocks:
+  - task-b
+---
+"#,
+        );
+
+        let mut sf = StatusFile::load(dir.path()).unwrap();
+        let report = migrate_file(&path, &mut sf, false).unwrap();
+        assert_eq!(report.kind, FileChange::Unchanged);
+    }
+
+    #[test]
+    fn migrate_skips_non_amos_files() {
+        let dir = tempdir().unwrap();
+        let path = write_md(
+            dir.path(),
+            "readme.md",
+            r#"---
+title: regular markdown
+---
+
+not an amos file
+"#,
+        );
+
+        let mut sf = StatusFile::load(dir.path()).unwrap();
+        let report = migrate_file(&path, &mut sf, false).unwrap();
+        assert_eq!(report.kind, FileChange::NotAmos);
+    }
+
+    #[test]
+    fn migrate_non_umbrella_first_asserts_no_umbrella_fields() {
+        // After the umbrella concept was removed, every `down:` entry becomes
+        // `blocks:` regardless of description content. This test confirms a
+        // description that used to trigger the heuristic is no longer treated
+        // specially.
+        let dir = tempdir().unwrap();
+        let path = write_md(
+            dir.path(),
+            "u.md",
+            r#"---
+whoami: amos
+name: tracking-node
+description: "Umbrella — overarching plan"
+dependencies:
+  - down:child-a
+  - down:child-b
+---
+"#,
+        );
+
+        let mut sf = StatusFile::load(dir.path()).unwrap();
+        let report = migrate_file(&path, &mut sf, false).unwrap();
+        assert_eq!(report.kind, FileChange::Migrated);
+        assert_eq!(report.blocks_added, 2);
+        assert_eq!(report.blocked_by_added, 0);
+
+        let after = fs::read_to_string(&path).unwrap();
+        assert!(after.contains("blocks:"));
+        assert!(!after.contains("children:"));
+    }
+
+    #[test]
+    fn migrate_dry_run_leaves_file_untouched() {
+        let dir = tempdir().unwrap();
+        let original = r#"---
+whoami: amos
+name: task-a
+dependencies:
+  - up:other
+---
+"#;
+        let path = write_md(dir.path(), "a.md", original);
+
+        let mut sf = StatusFile::load(dir.path()).unwrap();
+        let report = migrate_file(&path, &mut sf, true).unwrap();
+        assert_eq!(report.kind, FileChange::Migrated);
+
+        let after = fs::read_to_string(&path).unwrap();
+        assert_eq!(after, original, "dry-run must not modify the file");
+    }
+}

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,8 +1,35 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::adapter::{AdapterRegistry, ResourceFields};
 use crate::dag::Dag;
 use crate::resolver;
+
+/// Compare two node names with natural-numeric ordering.
+///
+/// Handles `@github:owner/repo#N` by extracting the trailing `#N` and comparing
+/// numerically when both sides share the same prefix, so `#99` sorts before
+/// `#100` instead of after it. Falls back to lexicographic comparison for
+/// non-numeric names or mixed shapes.
+pub fn numeric_aware_cmp(a: &str, b: &str) -> std::cmp::Ordering {
+    if let (Some((a_prefix, a_num)), Some((b_prefix, b_num))) = (
+        split_numeric_suffix(a),
+        split_numeric_suffix(b),
+    ) {
+        if a_prefix == b_prefix {
+            return a_num.cmp(&b_num);
+        }
+    }
+    a.cmp(b)
+}
+
+/// Split a name like `@github:owner/repo#123` into (`@github:owner/repo#`, 123).
+/// Returns None if the name doesn't end in `#<digits>`.
+fn split_numeric_suffix(s: &str) -> Option<(&str, u64)> {
+    let hash_pos = s.rfind('#')?;
+    let (prefix, rest) = s.split_at(hash_pos + 1);
+    let n: u64 = rest.parse().ok()?;
+    Some((prefix, n))
+}
 
 /// Batch-resolve all adapter-backed nodes in the DAG.
 /// Returns a map of node name → resolved facts.
@@ -77,17 +104,17 @@ pub fn format_dag(dag: &Dag, registry: &AdapterRegistry) -> String {
         }
         out.push('\n');
 
-        if !node.upstream.is_empty() {
+        if !node.blocked_by.is_empty() {
             let deps: Vec<String> = node
-                .upstream
+                .blocked_by
                 .iter()
                 .map(|u| format_dep_ref(u, &resolved))
                 .collect();
-            out.push_str(&format!("  depends on: {}\n", deps.join(", ")));
+            out.push_str(&format!("  blocked_by: {}\n", deps.join(", ")));
         }
-        if !node.downstream.is_empty() {
+        if !node.blocks.is_empty() {
             let blocks: Vec<String> = node
-                .downstream
+                .blocks
                 .iter()
                 .map(|d| format_dep_ref(d, &resolved))
                 .collect();
@@ -220,12 +247,12 @@ pub fn format_node(dag: &Dag, name: &str, registry: &AdapterRegistry) -> String 
         out.push_str(&format!("\n{}\n", desc));
     }
 
-    if !node.upstream.is_empty() {
-        out.push_str(&format!("\n**depends on:** {}\n", node.upstream.join(", ")));
+    if !node.blocked_by.is_empty() {
+        out.push_str(&format!("\n**blocked_by:** {}\n", node.blocked_by.join(", ")));
     }
 
-    if !node.downstream.is_empty() {
-        out.push_str(&format!("**blocks:** {}\n", node.downstream.join(", ")));
+    if !node.blocks.is_empty() {
+        out.push_str(&format!("**blocks:** {}\n", node.blocks.join(", ")));
     }
 
     if !node.body.is_empty() {
@@ -246,7 +273,15 @@ pub fn format_node(dag: &Dag, name: &str, registry: &AdapterRegistry) -> String 
 }
 
 /// Format the DAG as an ASCII dependency tree with live adapter facts.
-pub fn format_graph(dag: &Dag, registry: &AdapterRegistry) -> String {
+///
+/// Prepends a `## Issues` section when validation problems are present (missing
+/// deps, cycles, dangling context). The scan_root is needed to resolve local
+/// file context references when validating.
+pub fn format_graph(
+    dag: &Dag,
+    registry: &AdapterRegistry,
+    scan_root: &std::path::Path,
+) -> String {
     let mut out = String::new();
 
     let nodes = dag.all_nodes();
@@ -254,16 +289,28 @@ pub fn format_graph(dag: &Dag, registry: &AdapterRegistry) -> String {
         return out;
     }
 
+    // Surface any validation issues before the tree so users notice them.
+    let issues = dag.validate(scan_root);
+    if !issues.is_empty() {
+        out.push_str("## Issues\n\n");
+        for issue in &issues {
+            out.push_str(&format!("- {}\n", issue));
+        }
+        out.push('\n');
+    }
+
     // Batch-resolve adapter facts
     let resolved = resolve_all_facts(dag, registry);
 
-    // Find root nodes (no upstream dependencies)
+    // Roots = nodes with no incoming Blocks edges (nothing blocks them).
+    // The tree walks Blocks-kind edges only, so Related/Duplicates/Supersedes
+    // don't create extra branches or loops.
     let mut roots: Vec<&crate::parser::Node> = nodes
         .iter()
-        .filter(|n| dag.upstream_of(&n.name).is_empty())
+        .filter(|n| dag.blocked_by_of(&n.name).is_empty())
         .copied()
         .collect();
-    roots.sort_by(|a, b| a.name.cmp(&b.name));
+    roots.sort_by(|a, b| numeric_aware_cmp(&a.name, &b.name));
 
     let mut printed = std::collections::HashSet::new();
 
@@ -318,8 +365,37 @@ fn format_tree_node(
         prefix, connector, facts_tag, display, desc
     ));
 
-    let mut children: Vec<_> = dag.downstream_of(name);
-    children.sort_by(|a, b| a.name.cmp(&b.name));
+    // Children are ordered by the parent's declared `blocks:` list (preserving
+    // authoring order), with any additional DAG-derived children (e.g. edges
+    // created by another node's `blocked_by:` pointing at this node) appended
+    // at the end sorted numerically. Only Blocks-kind edges count — Related,
+    // Duplicates, and Supersedes don't create tree branches.
+    let dag_children = dag.blocks_of(name);
+    let dag_child_names: HashSet<&str> =
+        dag_children.iter().map(|n| n.name.as_str()).collect();
+
+    let mut children: Vec<&crate::parser::Node> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+
+    if let Some(parent_node) = dag.get_node(name) {
+        for declared in &parent_node.blocks {
+            if dag_child_names.contains(declared.as_str()) {
+                if let Some(child) = dag.get_node(declared) {
+                    if seen.insert(declared.clone()) {
+                        children.push(child);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut extras: Vec<&crate::parser::Node> = dag_children
+        .iter()
+        .filter(|n| !seen.contains(&n.name))
+        .copied()
+        .collect();
+    extras.sort_by(|a, b| numeric_aware_cmp(&a.name, &b.name));
+    children.extend(extras);
 
     let child_prefix = if prefix.is_empty() {
         "    ".to_string()
@@ -343,4 +419,146 @@ fn shorten_name(name: &str) -> String {
         }
     }
     name.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapter::AdapterRegistry;
+    use crate::dag::Dag;
+    use crate::parser::Node;
+    use std::cmp::Ordering;
+    use std::path::PathBuf;
+
+    fn node(name: &str, blocks: Vec<&str>) -> Node {
+        Node {
+            name: name.to_string(),
+            description: None,
+            blocked_by: Vec::new(),
+            blocks: blocks.into_iter().map(String::from).collect(),
+            related_to: Vec::new(),
+            duplicates: None,
+            superseded_by: None,
+            labels: Vec::new(),
+            priority: None,
+            context: Vec::new(),
+            adapters: std::collections::HashMap::new(),
+            source_file: PathBuf::from("test.md"),
+            line_number: 1,
+            body: String::new(),
+        }
+    }
+
+    #[test]
+    fn numeric_cmp_sorts_github_issues_numerically() {
+        let a = "@github:tatolab/streamlib#99";
+        let b = "@github:tatolab/streamlib#100";
+        assert_eq!(numeric_aware_cmp(a, b), Ordering::Less);
+    }
+
+    #[test]
+    fn numeric_cmp_equal_same_number() {
+        let a = "@github:tatolab/streamlib#42";
+        let b = "@github:tatolab/streamlib#42";
+        assert_eq!(numeric_aware_cmp(a, b), Ordering::Equal);
+    }
+
+    #[test]
+    fn numeric_cmp_different_prefixes_lexicographic() {
+        let a = "@github:tatolab/streamlib#1";
+        let b = "@github:tatolab/amos#100";
+        // Different prefixes -> lexicographic (streamlib > amos, regardless of number)
+        assert_eq!(numeric_aware_cmp(a, b), Ordering::Greater);
+    }
+
+    #[test]
+    fn numeric_cmp_non_numeric_names_lexicographic() {
+        assert_eq!(numeric_aware_cmp("alpha", "beta"), Ordering::Less);
+    }
+
+    #[test]
+    fn tree_preserves_declared_downstream_order() {
+        // Parent declares children in non-alphabetic order: c, a, b.
+        let nodes = vec![
+            node("p", vec!["c", "a", "b"]),
+            node("a", vec![]),
+            node("b", vec![]),
+            node("c", vec![]),
+        ];
+        let dag = Dag::build(nodes).unwrap();
+        let registry = AdapterRegistry::new();
+        let tree = format_graph(&dag, &registry, std::path::Path::new("."));
+
+        // Children should appear in declared order: c, a, b
+        let c_pos = tree.find("── c").expect("c present");
+        let a_pos = tree.find("── a").expect("a present");
+        let b_pos = tree.find("── b").expect("b present");
+        assert!(c_pos < a_pos, "c should come before a (declared order)");
+        assert!(a_pos < b_pos, "a should come before b (declared order)");
+    }
+
+    #[test]
+    fn graph_prepends_issues_when_validation_fails() {
+        // A node references a nonexistent blocks target — validate() should
+        // emit a MissingDependency issue, and format_graph should surface it.
+        let n = node("a", vec!["ghost"]);
+        let dag = Dag::build(vec![n]).unwrap();
+        let registry = AdapterRegistry::new();
+        let tree = format_graph(&dag, &registry, std::path::Path::new("."));
+
+        assert!(
+            tree.contains("## Issues"),
+            "expected Issues section, got: {}",
+            tree
+        );
+        assert!(
+            tree.contains("ghost"),
+            "expected missing dep name in issues section, got: {}",
+            tree
+        );
+    }
+
+    #[test]
+    fn graph_omits_issues_section_when_clean() {
+        let nodes = vec![node("a", vec!["b"]), node("b", vec![])];
+        let dag = Dag::build(nodes).unwrap();
+        let registry = AdapterRegistry::new();
+        let tree = format_graph(&dag, &registry, std::path::Path::new("."));
+        assert!(
+            !tree.contains("## Issues"),
+            "expected no Issues section when DAG is clean, got: {}",
+            tree
+        );
+    }
+
+    #[test]
+    fn tree_appends_undeclared_children_numerically_sorted() {
+        // Parent declares only #320 and #322; #321 becomes a child via its
+        // own `blocked_by:` ref, so it's not in the parent's declared list.
+        let p_name = "@github:org/repo#1";
+        let c320 = "@github:org/repo#320";
+        let c321 = "@github:org/repo#321";
+        let c322 = "@github:org/repo#322";
+
+        let parent = node(p_name, vec![c320, c322]);
+        let mut n321 = node(c321, vec![]);
+        n321.blocked_by = vec![p_name.to_string()]; // adds edge p -> 321 via blocked_by:
+
+        let nodes = vec![
+            parent,
+            node(c320, vec![]),
+            n321,
+            node(c322, vec![]),
+        ];
+        let dag = Dag::build(nodes).unwrap();
+        let registry = AdapterRegistry::new();
+        let tree = format_graph(&dag, &registry, std::path::Path::new("."));
+
+        let p320 = tree.find("#320").expect("320 present");
+        let p321 = tree.find("#321").expect("321 present");
+        let p322 = tree.find("#322").expect("322 present");
+        // Declared order first (320, 322), then extras (321)
+        assert!(p320 < p322, "declared 320 before declared 322");
+        assert!(p322 < p321, "undeclared 321 appears after declared list");
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,10 +12,26 @@ pub struct Node {
     pub name: String,
     /// Plain-language description of the work.
     pub description: Option<String>,
-    /// Upstream dependencies (nodes this depends on).
-    pub upstream: Vec<String>,
-    /// Downstream dependents (nodes that depend on this).
-    pub downstream: Vec<String>,
+
+    // --- Typed relationships. ---
+    /// Nodes that must complete before this one can start.
+    pub blocked_by: Vec<String>,
+    /// Nodes that can't start until this one is done.
+    pub blocks: Vec<String>,
+    /// Soft associations — no ordering or gating.
+    pub related_to: Vec<String>,
+    /// This node duplicates another (that one is canonical).
+    pub duplicates: Option<String>,
+    /// This node has been replaced by another.
+    pub superseded_by: Option<String>,
+
+    // --- Attributes. ---
+    /// Free-form tags for filtering.
+    pub labels: Vec<String>,
+    /// Priority bucket.
+    pub priority: Option<Priority>,
+
+    // --- Existing fields. ---
     /// Context references (local files, @github:, @url:).
     pub context: Vec<ContextRef>,
     /// Adapter declarations — scheme → source URI for auto-pull.
@@ -26,6 +42,31 @@ pub struct Node {
     pub line_number: usize,
     /// Markdown body after the frontmatter block.
     pub body: String,
+}
+
+/// Priority bucket, ordered from highest (P0) to lowest (P3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Priority {
+    P0,
+    P1,
+    P2,
+    P3,
+}
+
+impl std::str::FromStr for Priority {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "p0" | "0" => Ok(Priority::P0),
+            "p1" | "1" => Ok(Priority::P1),
+            "p2" | "2" => Ok(Priority::P2),
+            "p3" | "3" => Ok(Priority::P3),
+            other => Err(format!(
+                "invalid priority '{}'; expected p0, p1, p2, or p3",
+                other
+            )),
+        }
+    }
 }
 
 /// A context reference pointing to a file or URL.
@@ -49,8 +90,25 @@ struct RawFrontmatter {
     whoami: String,
     name: String,
     description: Option<String>,
+
+    // Typed relationships.
     #[serde(default)]
-    dependencies: Vec<String>,
+    blocked_by: Vec<String>,
+    #[serde(default)]
+    blocks: Vec<String>,
+    #[serde(default)]
+    related_to: Vec<String>,
+    #[serde(default)]
+    duplicates: Option<String>,
+    #[serde(default)]
+    superseded_by: Option<String>,
+
+    // Attributes.
+    #[serde(default)]
+    labels: Vec<String>,
+    #[serde(default)]
+    priority: Option<String>,
+
     #[serde(default)]
     context: Vec<String>,
     #[serde(default)]
@@ -59,6 +117,34 @@ struct RawFrontmatter {
 
 /// Parse a raw block into a Node.
 pub fn parse_block(block: &RawBlock) -> Result<Node> {
+    // Legacy-format detection: the old `dependencies:` list with up:/down:
+    // prefixes and the in-frontmatter `status:` field both moved out in
+    // favor of typed edges and `.amos-status`. Point users to the migration
+    // tool rather than silently dropping fields.
+    let raw: serde_yaml::Value = serde_yaml::from_str(&block.yaml).with_context(|| {
+        format!(
+            "parsing YAML at {}:{}",
+            block.source_file.display(),
+            block.line_number
+        )
+    })?;
+    if let Some(map) = raw.as_mapping() {
+        if map.contains_key("dependencies") {
+            bail!(
+                "legacy `dependencies:` field in {}:{} — run `amos migrate` to convert to typed edges (blocked_by:/blocks:)",
+                block.source_file.display(),
+                block.line_number
+            );
+        }
+        if map.contains_key("status") {
+            bail!(
+                "legacy `status:` field in {}:{} — run `amos migrate` to move status entries into .amos-status",
+                block.source_file.display(),
+                block.line_number
+            );
+        }
+    }
+
     let frontmatter: RawFrontmatter =
         serde_yaml::from_str(&block.yaml).with_context(|| {
             format!(
@@ -85,24 +171,6 @@ pub fn parse_block(block: &RawBlock) -> Result<Node> {
         );
     }
 
-    let mut upstream = Vec::new();
-    let mut downstream = Vec::new();
-
-    for dep in &frontmatter.dependencies {
-        if let Some(name) = dep.strip_prefix("up:") {
-            upstream.push(name.trim().to_string());
-        } else if let Some(name) = dep.strip_prefix("down:") {
-            downstream.push(name.trim().to_string());
-        } else {
-            bail!(
-                "invalid dependency '{}' at {}:{} — must start with 'up:' or 'down:'",
-                dep,
-                block.source_file.display(),
-                block.line_number
-            );
-        }
-    }
-
     let context = frontmatter
         .context
         .iter()
@@ -116,11 +184,31 @@ pub fn parse_block(block: &RawBlock) -> Result<Node> {
             )
         })?;
 
+    let priority = frontmatter
+        .priority
+        .as_deref()
+        .map(|s| {
+            s.parse::<Priority>().map_err(|e| {
+                anyhow::anyhow!(
+                    "{} at {}:{}",
+                    e,
+                    block.source_file.display(),
+                    block.line_number
+                )
+            })
+        })
+        .transpose()?;
+
     Ok(Node {
         name: frontmatter.name,
         description: frontmatter.description,
-        upstream,
-        downstream,
+        blocked_by: frontmatter.blocked_by,
+        blocks: frontmatter.blocks,
+        related_to: frontmatter.related_to,
+        duplicates: frontmatter.duplicates,
+        superseded_by: frontmatter.superseded_by,
+        labels: frontmatter.labels,
+        priority,
         context,
         adapters: frontmatter.adapters,
         source_file: block.source_file.clone(),
@@ -194,7 +282,7 @@ description: First task"#,
     }
 
     #[test]
-    fn test_parse_dependencies() {
+    fn test_legacy_dependencies_errors_with_migrate_hint() {
         let block = make_block(
             r#"whoami: amos
 name: task-b
@@ -203,9 +291,22 @@ dependencies:
   - down:task-c"#,
             "",
         );
-        let node = parse_block(&block).unwrap();
-        assert_eq!(node.upstream, vec!["task-a"]);
-        assert_eq!(node.downstream, vec!["task-c"]);
+        let err = parse_block(&block).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("amos migrate"), "expected migrate hint: {}", msg);
+    }
+
+    #[test]
+    fn test_legacy_status_errors_with_migrate_hint() {
+        let block = make_block(
+            r#"whoami: amos
+name: task-a
+status: pending"#,
+            "",
+        );
+        let err = parse_block(&block).unwrap_err();
+        let msg = format!("{}", err);
+        assert!(msg.contains("amos migrate"), "expected migrate hint: {}", msg);
     }
 
     #[test]
@@ -239,17 +340,8 @@ context:
         );
     }
 
-    #[test]
-    fn test_invalid_dependency_prefix() {
-        let block = make_block(
-            r#"whoami: amos
-name: task-a
-dependencies:
-  - invalid-dep"#,
-            "",
-        );
-        assert!(parse_block(&block).is_err());
-    }
+    // Legacy `dependencies:` now errors with a migrate hint; see
+    // test_legacy_dependencies_errors_with_migrate_hint for the new behavior.
 
     #[test]
     fn test_minimal_node() {
@@ -257,8 +349,86 @@ dependencies:
         let node = parse_block(&block).unwrap();
         assert_eq!(node.name, "task-a");
         assert!(node.description.is_none());
-        assert!(node.upstream.is_empty());
-        assert!(node.downstream.is_empty());
         assert!(node.context.is_empty());
+        assert!(node.blocked_by.is_empty());
+        assert!(node.blocks.is_empty());
+        assert!(node.related_to.is_empty());
+        assert!(node.labels.is_empty());
+        assert!(node.priority.is_none());
     }
+
+    #[test]
+    fn test_parse_typed_relationships() {
+        let block = make_block(
+            r#"whoami: amos
+name: "@github:tatolab/streamlib#326"
+blocked_by:
+  - "@github:tatolab/streamlib#325"
+  - "@github:tatolab/streamlib#369"
+blocks:
+  - "@github:tatolab/streamlib#999"
+related_to:
+  - "@github:tatolab/streamlib#888"
+duplicates: "@github:tatolab/streamlib#777"
+superseded_by: "@github:tatolab/streamlib#555""#,
+            "",
+        );
+        let node = parse_block(&block).unwrap();
+        assert_eq!(node.blocked_by.len(), 2);
+        assert_eq!(node.blocked_by[0], "@github:tatolab/streamlib#325");
+        assert_eq!(node.blocked_by[1], "@github:tatolab/streamlib#369");
+        assert_eq!(node.blocks, vec!["@github:tatolab/streamlib#999"]);
+        assert_eq!(node.related_to, vec!["@github:tatolab/streamlib#888"]);
+        assert_eq!(
+            node.duplicates.as_deref(),
+            Some("@github:tatolab/streamlib#777")
+        );
+        assert_eq!(
+            node.superseded_by.as_deref(),
+            Some("@github:tatolab/streamlib#555")
+        );
+    }
+
+    #[test]
+    fn test_parse_attributes() {
+        let block = make_block(
+            r#"whoami: amos
+name: task-a
+labels:
+  - refactor
+  - gpu
+priority: p2"#,
+            "",
+        );
+        let node = parse_block(&block).unwrap();
+        assert_eq!(node.labels, vec!["refactor", "gpu"]);
+        assert_eq!(node.priority, Some(Priority::P2));
+    }
+
+    #[test]
+    fn test_parse_priority_alternate_forms() {
+        for (raw, expected) in [
+            ("p0", Priority::P0),
+            ("P1", Priority::P1),
+            ("2", Priority::P2),
+            ("P3", Priority::P3),
+        ] {
+            let block = make_block(
+                &format!("whoami: amos\nname: t\npriority: \"{}\"", raw),
+                "",
+            );
+            let node = parse_block(&block).unwrap();
+            assert_eq!(node.priority, Some(expected), "failed for raw={}", raw);
+        }
+    }
+
+    #[test]
+    fn test_parse_invalid_priority_errors() {
+        let block = make_block(
+            "whoami: amos\nname: t\npriority: urgent",
+            "",
+        );
+        assert!(parse_block(&block).is_err());
+    }
+
 }

--- a/src/rename.rs
+++ b/src/rename.rs
@@ -1,0 +1,287 @@
+//! `amos rename` — rewrite a node's `name:` and every reference to it.
+//!
+//! Stale references (one file's `blocked_by:` points at a name that was
+//! renamed in another file) silently break DAG edges — the edge string
+//! doesn't match anything, and the rendered graph just drops the
+//! relationship. This command does a coordinated rename across the whole
+//! scan tree.
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Per-file rename result.
+#[derive(Debug, Clone)]
+pub struct FileRenameReport {
+    pub path: PathBuf,
+    /// True if this file was the source of the renamed node (had `name: <old>`).
+    pub name_updated: bool,
+    /// How many reference lines were rewritten (frontmatter values + body
+    /// `@scheme:` refs combined).
+    pub refs_updated: usize,
+}
+
+#[derive(Debug, Default)]
+pub struct RenameReport {
+    pub files: Vec<FileRenameReport>,
+}
+
+impl RenameReport {
+    pub fn total_refs_updated(&self) -> usize {
+        self.files.iter().map(|r| r.refs_updated).sum()
+    }
+
+    pub fn files_changed(&self) -> usize {
+        self.files
+            .iter()
+            .filter(|r| r.name_updated || r.refs_updated > 0)
+            .count()
+    }
+
+    pub fn summary(&self) -> String {
+        format!(
+            "{} files changed, {} references updated",
+            self.files_changed(),
+            self.total_refs_updated()
+        )
+    }
+}
+
+/// Rename `old_name` to `new_name` across every `.md` file under `scan_root`.
+///
+/// Rewrites:
+/// - `name: <old_name>` → `name: <new_name>` (on whatever file defines it)
+/// - Every `blocked_by:`, `blocks:`, `related_to:`, `duplicates:`,
+///   `superseded_by:` list entry or scalar value that equals `old_name`.
+/// - Every body reference whose string equals `old_name`.
+///
+/// With `dry_run` set, no files are written; the report still describes what
+/// would change.
+pub fn rename_tree(
+    scan_root: &Path,
+    old_name: &str,
+    new_name: &str,
+    dry_run: bool,
+) -> Result<RenameReport> {
+    let mut report = RenameReport::default();
+
+    let walker = ignore::WalkBuilder::new(scan_root)
+        .standard_filters(true)
+        .build();
+
+    for entry in walker.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if path.extension().and_then(|s| s.to_str()) != Some("md") {
+            continue;
+        }
+        let file_report = rename_in_file(path, old_name, new_name, dry_run)?;
+        report.files.push(file_report);
+    }
+
+    Ok(report)
+}
+
+fn rename_in_file(
+    path: &Path,
+    old_name: &str,
+    new_name: &str,
+    dry_run: bool,
+) -> Result<FileRenameReport> {
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("reading {}", path.display()))?;
+
+    let mut new_content = String::with_capacity(content.len());
+    let mut name_updated = false;
+    let mut refs_updated = 0usize;
+
+    for line in content.split_inclusive('\n') {
+        let rewritten = rewrite_line(line, old_name, new_name, &mut name_updated, &mut refs_updated);
+        new_content.push_str(&rewritten);
+    }
+
+    if (name_updated || refs_updated > 0) && !dry_run {
+        fs::write(path, &new_content)
+            .with_context(|| format!("writing renamed {}", path.display()))?;
+    }
+
+    Ok(FileRenameReport {
+        path: path.to_path_buf(),
+        name_updated,
+        refs_updated,
+    })
+}
+
+/// Rewrite a single line. Looks for:
+/// - `name:` frontmatter line whose value matches `old_name`.
+/// - Any quoted or bare occurrence of `old_name` as a whole YAML scalar.
+/// Avoids partial-string matches (a substring inside a longer name).
+fn rewrite_line(
+    line: &str,
+    old_name: &str,
+    new_name: &str,
+    name_updated: &mut bool,
+    refs_updated: &mut usize,
+) -> String {
+    // Cheap early-out if the name isn't anywhere in the line.
+    if !line.contains(old_name) {
+        return line.to_string();
+    }
+
+    // Split off trailing newline(s) so we can work on the textual part.
+    let (text, trailing_newlines) = split_trailing_newlines(line);
+
+    // Find all occurrences of old_name as a "whole token" — preceded and
+    // followed by characters that can't be part of the identifier. YAML
+    // quoting (`"`, `'`), whitespace, comma, bracket, end-of-string all count.
+    let mut rewritten = String::with_capacity(text.len());
+    let mut cursor = 0;
+    let bytes = text.as_bytes();
+    let old_bytes = old_name.as_bytes();
+
+    while cursor < text.len() {
+        if let Some(rel) = text[cursor..].find(old_name) {
+            let abs = cursor + rel;
+            let before_ok = abs == 0
+                || is_boundary_byte(bytes[abs - 1]);
+            let after_end = abs + old_bytes.len();
+            let after_ok = after_end >= bytes.len()
+                || is_boundary_byte(bytes[after_end]);
+
+            // Copy the segment up to the match.
+            rewritten.push_str(&text[cursor..abs]);
+
+            if before_ok && after_ok {
+                rewritten.push_str(new_name);
+                // Heuristic: if this line starts with `name:` and the match
+                // lands after the colon, this is the defining name.
+                let trimmed_prefix = text[..abs].trim_start();
+                if trimmed_prefix.starts_with("name:") {
+                    *name_updated = true;
+                } else {
+                    *refs_updated += 1;
+                }
+            } else {
+                // Not a word boundary — leave as-is.
+                rewritten.push_str(&text[abs..abs + old_bytes.len()]);
+            }
+            cursor = abs + old_bytes.len();
+        } else {
+            rewritten.push_str(&text[cursor..]);
+            break;
+        }
+    }
+
+    rewritten.push_str(trailing_newlines);
+    rewritten
+}
+
+fn is_boundary_byte(b: u8) -> bool {
+    matches!(
+        b,
+        b'"' | b'\'' | b' ' | b'\t' | b',' | b'[' | b']' | b'(' | b')' | b'\n' | b'\r'
+    )
+}
+
+fn split_trailing_newlines(line: &str) -> (&str, &str) {
+    let trimmed = line.trim_end_matches(['\n', '\r']);
+    let trailing_len = line.len() - trimmed.len();
+    (trimmed, &line[line.len() - trailing_len..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn write_md(dir: &Path, name: &str, content: &str) -> PathBuf {
+        let p = dir.join(name);
+        fs::write(&p, content).unwrap();
+        p
+    }
+
+    #[test]
+    fn rename_updates_name_field_and_refs() {
+        let dir = tempdir().unwrap();
+        let a = write_md(
+            dir.path(),
+            "a.md",
+            r#"---
+whoami: amos
+name: "@github:org/repo#1"
+blocks:
+  - "@github:org/repo#2"
+---
+"#,
+        );
+        let b = write_md(
+            dir.path(),
+            "b.md",
+            r#"---
+whoami: amos
+name: "@github:org/repo#2"
+blocked_by:
+  - "@github:org/repo#1"
+---
+"#,
+        );
+
+        let report = rename_tree(
+            dir.path(),
+            "@github:org/repo#1",
+            "@github:org/repo#999",
+            false,
+        )
+        .unwrap();
+        assert_eq!(report.files_changed(), 2);
+
+        let a_after = fs::read_to_string(&a).unwrap();
+        assert!(a_after.contains("@github:org/repo#999"));
+        assert!(!a_after.contains("@github:org/repo#1\""));
+
+        let b_after = fs::read_to_string(&b).unwrap();
+        assert!(b_after.contains("blocked_by"));
+        assert!(b_after.contains("@github:org/repo#999"));
+    }
+
+    #[test]
+    fn rename_dry_run_leaves_files_untouched() {
+        let dir = tempdir().unwrap();
+        let original = r#"---
+whoami: amos
+name: "task-a"
+---
+"#;
+        let path = write_md(dir.path(), "x.md", original);
+
+        let report =
+            rename_tree(dir.path(), "task-a", "task-b", true).unwrap();
+        assert_eq!(report.files_changed(), 1);
+
+        let after = fs::read_to_string(&path).unwrap();
+        assert_eq!(after, original);
+    }
+
+    #[test]
+    fn rename_does_not_match_partial_substrings() {
+        let dir = tempdir().unwrap();
+        let path = write_md(
+            dir.path(),
+            "a.md",
+            r#"---
+whoami: amos
+name: task-a-long
+---
+"#,
+        );
+
+        let report = rename_tree(dir.path(), "task-a", "renamed", false).unwrap();
+        assert_eq!(report.files_changed(), 0);
+
+        let after = fs::read_to_string(&path).unwrap();
+        assert!(after.contains("task-a-long"));
+        assert!(!after.contains("renamed"));
+    }
+}

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,0 +1,210 @@
+//! `.amos-status` file handling.
+//!
+//! Status lives outside the plan files so they stay pure specs. The status
+//! file is a plain markdown checklist at the scan root; each line names a node
+//! with a checkbox state:
+//!
+//! ```text
+//! - [x] @github:tatolab/streamlib#320
+//! - [~] @github:tatolab/streamlib#325
+//! - [ ] @github:tatolab/streamlib#326
+//! ```
+//!
+//! `[x]` = done, `[~]` = in-progress, `[ ]` (or absence) = pending. Anything
+//! not listed in the file is treated as pending.
+
+use anyhow::{Context, Result};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub const STATUS_FILENAME: &str = ".amos-status";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    Pending,
+    InProgress,
+    Done,
+}
+
+impl Status {
+    pub fn checkbox(&self) -> char {
+        match self {
+            Status::Pending => ' ',
+            Status::InProgress => '~',
+            Status::Done => 'x',
+        }
+    }
+}
+
+/// Parsed `.amos-status` file, keyed by node name.
+#[derive(Debug, Default, Clone)]
+pub struct StatusFile {
+    path: PathBuf,
+    entries: HashMap<String, Status>,
+}
+
+impl StatusFile {
+    /// Load the status file at `<scan_root>/.amos-status`. Missing file returns
+    /// an empty StatusFile — not an error.
+    pub fn load(scan_root: &Path) -> Result<Self> {
+        let path = scan_root.join(STATUS_FILENAME);
+        if !path.exists() {
+            return Ok(Self {
+                path,
+                entries: HashMap::new(),
+            });
+        }
+        let content = fs::read_to_string(&path)
+            .with_context(|| format!("reading {}", path.display()))?;
+        let mut entries = HashMap::new();
+        for line in content.lines() {
+            if let Some((status, name)) = parse_line(line) {
+                entries.insert(name, status);
+            }
+        }
+        Ok(Self { path, entries })
+    }
+
+    pub fn get(&self, name: &str) -> Status {
+        self.entries.get(name).copied().unwrap_or(Status::Pending)
+    }
+
+    pub fn set(&mut self, name: &str, status: Status) {
+        if matches!(status, Status::Pending) {
+            self.entries.remove(name);
+        } else {
+            self.entries.insert(name.to_string(), status);
+        }
+    }
+
+    pub fn remove(&mut self, name: &str) {
+        self.entries.remove(name);
+    }
+
+    /// Write the file back, sorting entries by name for a stable diff.
+    pub fn save(&self) -> Result<()> {
+        let mut lines: Vec<String> = self
+            .entries
+            .iter()
+            .map(|(name, status)| format!("- [{}] {}", status.checkbox(), name))
+            .collect();
+        lines.sort();
+
+        if lines.is_empty() {
+            // Don't leave an empty file on disk; remove instead.
+            if self.path.exists() {
+                fs::remove_file(&self.path)
+                    .with_context(|| format!("removing empty {}", self.path.display()))?;
+            }
+            return Ok(());
+        }
+
+        let content = lines.join("\n") + "\n";
+        fs::write(&self.path, content)
+            .with_context(|| format!("writing {}", self.path.display()))?;
+        Ok(())
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+/// Parse a single `- [X] name` line. Ignores blank/comment lines.
+fn parse_line(line: &str) -> Option<(Status, String)> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+    let rest = trimmed.strip_prefix("- [")?;
+    let (state_char, rest) = rest.split_once(']')?;
+    let state = match state_char.trim() {
+        "x" | "X" => Status::Done,
+        "~" => Status::InProgress,
+        "" | " " => Status::Pending,
+        _ => return None,
+    };
+    let name = rest.trim().to_string();
+    if name.is_empty() {
+        None
+    } else {
+        Some((state, name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    #[test]
+    fn parse_basic_entries() {
+        assert_eq!(
+            parse_line("- [x] @github:org/repo#1"),
+            Some((Status::Done, "@github:org/repo#1".to_string()))
+        );
+        assert_eq!(
+            parse_line("- [~] in-progress-task"),
+            Some((Status::InProgress, "in-progress-task".to_string()))
+        );
+        assert_eq!(
+            parse_line("- [ ] pending-task"),
+            Some((Status::Pending, "pending-task".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_skips_non_entry_lines() {
+        assert_eq!(parse_line(""), None);
+        assert_eq!(parse_line("# header"), None);
+        assert_eq!(parse_line("random text"), None);
+        assert_eq!(parse_line("- [y] unknown-state"), None);
+    }
+
+    #[test]
+    fn roundtrip_save_and_load() {
+        let dir = tempdir().unwrap();
+        let mut sf = StatusFile::load(dir.path()).unwrap();
+        assert!(sf.is_empty());
+
+        sf.set("node-a", Status::Done);
+        sf.set("node-b", Status::InProgress);
+        sf.save().unwrap();
+
+        let reloaded = StatusFile::load(dir.path()).unwrap();
+        assert_eq!(reloaded.get("node-a"), Status::Done);
+        assert_eq!(reloaded.get("node-b"), Status::InProgress);
+        assert_eq!(reloaded.get("node-c"), Status::Pending);
+    }
+
+    #[test]
+    fn setting_pending_removes_entry() {
+        let dir = tempdir().unwrap();
+        let mut sf = StatusFile::load(dir.path()).unwrap();
+        sf.set("node-a", Status::Done);
+        sf.set("node-a", Status::Pending);
+        assert_eq!(sf.len(), 0);
+    }
+
+    #[test]
+    fn save_removes_file_when_empty() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join(STATUS_FILENAME);
+        // Seed a file
+        let mut f = fs::File::create(&path).unwrap();
+        writeln!(f, "- [x] node-a").unwrap();
+        drop(f);
+
+        let mut sf = StatusFile::load(dir.path()).unwrap();
+        sf.remove("node-a");
+        sf.save().unwrap();
+
+        assert!(!path.exists(), "empty status file should be removed");
+    }
+}


### PR DESCRIPTION
## Summary

Major refactor of amos's data model and CLI surface. Replaces the overloaded `dependencies: up:/down:` syntax with typed edges (`blocked_by` / `blocks` / `related_to` / `duplicates` / `superseded_by`) and wires a milestone-focused workflow that makes `/amos:next` a one-shot "pick up the next task" command instead of reading a protocol file every time.

## What's in the box

- **Typed edges** — five distinct relationship kinds in the DAG. No more guessing whether `down:X` means "X is my child" or "X waits for me."
- **Status moved to `.amos-status`** — out of frontmatter, back to the SPEC's original model. Now with real CLI support (`amos done` / `start` / `reset`).
- **`amos migrate`** — one-shot conversion of legacy plans to the new format. Literal mapping, `--dry-run` flag.
- **`amos validate`** — DAG integrity (missing deps, cycles, dangling context). Non-zero exit on errors so it gates pre-commit or CI.
- **`amos next` / `blocked` / `orphans`** — readiness queries.
- **`amos rename <old> <new>`** — rewrites a node's name and every reference; `--dry-run` available. Closes the silent-edge-breakage hole that originally motivated this refactor.
- **`amos focus <title>` / `amos milestones`** — milestone-aware workflow. `amos next` scopes to the focused milestone. GitHub adapter pulls milestone data.
- **Two new global skills** (`amos-focus`, `amos-next`) that replace per-project PROMPT.md files. `amos-next` does focus triage (no focus / done / blocked / ready) and can rank-recommend milestones when the user doesn't specify one.
- **`spec/SPEC.md`** rewritten as v0.6 to match reality.

## Data model rationale

No `parent:` / `children:` fields — grouping is intentionally delegated to GitHub milestones, resolved through the adapter. The earlier design attempt used an \"Umbrella\" keyword heuristic to classify plan files; that got confused by false positives and was ultimately redundant with GitHub's milestone feature. Better to lean on the existing primitive.

## Test plan

- [x] 57 unit tests passing (parser, DAG, output, status, migrate, rename, amosrc)
- [x] Smoke tested against streamlib plan set: `amos migrate` converts 80 legacy files cleanly; `amos validate` reports only expected external-reference issues; `amos focus` + `amos next` correctly surface ready items per milestone

## Migration path for existing amos users

Run `amos migrate --dry-run` first to see the diff, then `amos migrate` for real. The parser errors on legacy `dependencies:` blocks with a helpful pointer to the migrate command, so existing plans fail fast rather than silently being misinterpreted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)