### PR TITLE
feat: adapter-first enumeration + consistent issue filing

### DIFF
--- a/.claude/skills/amos-file/SKILL.md
+++ b/.claude/skills/amos-file/SKILL.md
@@ -147,6 +147,52 @@ label → "Polyglot SDK Realignment" milestone on streamlib). **Confidence tiers
   If the user picks "I'll tell you", ask for the title and validate it against
   the `amos milestones` list.
 
+## Step 4.5 — Infer the issue type
+
+GitHub has three repo-level issue types: **Bug**, **Feature**, **Task**.
+They're separate from labels and render with distinct icons in the UI.
+Amos passes `issue_type` through to `gh`'s `updateIssueIssueType`
+mutation — if the repo has the type configured, the new issue picks
+it up.
+
+Fetch available types (usually this is the standard three, but
+projects sometimes add more):
+
+```bash
+gh api graphql -f query='{
+  repository(owner:"<owner>",name:"<repo>") {
+    issueTypes(first:10) { nodes { name description } }
+  }
+}' | jq '.data.repository.issueTypes.nodes[]'
+```
+
+Infer from the draft:
+
+- **Bug** — describes a thing that is broken, throws an error, crashes,
+  fails a test, produces wrong output, regresses from a prior working
+  state. Conventional-commit prefix `fix(...)`.
+- **Feature** — a new capability that doesn't exist yet. Not a fix, not
+  maintenance. Conventional-commit prefix `feat(...)`.
+- **Task** — everything else. Chores, refactors, docs, research,
+  rollup retests, CI work, dependency bumps. Conventional-commit
+  prefixes `chore(...)`, `refactor(...)`, `docs(...)`, `test(...)`,
+  `perf(...)`, or no prefix for umbrellas and research tickets.
+
+If confidence is high (conventional-commit prefix matches cleanly),
+just set the type. If the draft title has no prefix and the content is
+ambiguous (e.g., "improve the caching story"), fall back to
+`AskUserQuestion`:
+
+```
+What type of issue is this?
+[ 1 ] Bug — something is broken
+[ 2 ] Feature — new capability
+[ 3 ] Task — maintenance, refactor, research, etc.
+```
+
+If the repo doesn't have any issue types configured, omit the field —
+the binary will skip the mutation cleanly.
+
 ## Step 5 — Infer labels
 
 ```bash
@@ -210,6 +256,7 @@ Present the draft in full, then `AskUserQuestion`:
 Ready to file this issue?
 
 Title:      <title>
+Type:       <issue_type or "none">
 Milestone:  <milestone or "none">
 Labels:     <label1, label2, ...>
 Blocked by: <list, or "none">
@@ -222,10 +269,11 @@ Parent:     <sub_issue_of, or "none">
 
 [ 1 ] File it as shown
 [ 2 ] Change the title
-[ 3 ] Change the milestone
-[ 4 ] Edit the body
-[ 5 ] Fix the relationships
-[ 6 ] Cancel
+[ 3 ] Change the type
+[ 4 ] Change the milestone
+[ 5 ] Edit the body
+[ 6 ] Fix the relationships
+[ 7 ] Cancel
 ```
 
 If the user picks anything but "File it as shown", iterate on the relevant
@@ -240,8 +288,9 @@ cat > /tmp/amos-spec.json <<'JSON'
 {
   "title": "fix(python): ...",
   "body": "## Description\n...",
+  "issue_type": "Bug",
   "milestone": "Polyglot SDK Realignment",
-  "labels": ["bug", "polyglot"],
+  "labels": ["polyglot"],
   "blocked_by": ["@github:tatolab/streamlib#322"],
   "blocks": [],
   "sub_issue_of": null

--- a/.claude/skills/amos-file/SKILL.md
+++ b/.claude/skills/amos-file/SKILL.md
@@ -61,11 +61,46 @@ Why this matters. Constraints, prior work, related discussion.
 ## Related
 - Milestone: <name>
 - See also: #N, #M
+
+<!-- amos:ai-notes-begin -->
+## AI Agent Notes
+
+Agent-facing context that doesn't belong in the human-readable sections
+above. Include only what's useful to a future agent walking in cold:
+
+- Exact error strings, VUIDs, stack traces from the conversation that
+  led to this issue (search-fuel for lookups).
+- Concrete file paths + line numbers relevant to the fix.
+- Approaches already tried or ruled out, with the reason.
+- Hidden constraints or invariants the code enforces.
+- Pointers to adjacent amos nodes or docs (`@github:owner/repo#N`,
+  `docs/learnings/foo.md`).
+
+Skip anything already obvious from the Description or Exit criteria —
+no duplication. If there's nothing agent-specific to add, leave an
+explicit "None." so a future reader knows it wasn't forgotten.
+<!-- amos:ai-notes-end -->
 ```
 
 **Do NOT** put `Blocked by:` / `Blocks:` in the `Related` section — those are
 set via native GitHub relationships, not text. The `Related` section is for
 human context only ("see also", "context from #N", etc.).
+
+**Always include the `AI Agent Notes` section** — even on issues without
+obvious agent-specific context. It's the contract between human-filed
+issues and agents picking them up later. The HTML markers
+(`<!-- amos:ai-notes-begin -->` / `<!-- amos:ai-notes-end -->`) are
+load-bearing: they let amos tooling find and update the section without
+risking the rest of the body.
+
+### Project-specific templates
+
+If the project has its own `docs/issue-template.md` or
+`.github/ISSUE_TEMPLATE/*.md`, use its sections verbatim — **but if it
+doesn't already include an AI Agent Notes section, append one at the end
+of the body** using the marker-wrapped shape above. The section is
+non-negotiable; it's how agents and humans share context on a remote-first
+issue.
 
 ## Step 3 — Draft title + body
 

--- a/.claude/skills/amos-file/SKILL.md
+++ b/.claude/skills/amos-file/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: amos-file
+description: >
+  File a new GitHub issue with a well-shaped body, the right milestone, and native
+  dependency relationships, from a short natural-language intent. Use when the user
+  says "file this", "open an issue for X", "create a ticket", "log this as a bug",
+  when discussion surfaces a new task that should be tracked, or after the
+  assistant offered to file something and the user confirmed. Infers milestone
+  and labels; uses AskUserQuestion whenever confidence is low.
+allowed-tools: Bash, Read, Write, AskUserQuestion, Glob, Grep
+---
+
+# Filing a new issue
+
+Your job is to produce a consistent, well-shaped GitHub issue from minimal input,
+so the user never has to hand-author a full template. You draft; the user approves
+via `AskUserQuestion`; amos executes atomically.
+
+Never skip the approval gate. Never execute a create on a draft the user hasn't
+seen in full.
+
+## Step 1 — Capture intent
+
+Use whatever the user already gave you:
+
+- An explicit request ("file an issue for the Python regex bug")
+- A conversation thread where a bug/task surfaced
+- A prior assistant prompt ("want me to file this?") + the user saying yes
+
+If the intent is too vague to produce a draft, ask one concrete question via
+`AskUserQuestion` — e.g. "Should this be a bug report, a feature request, or a
+research task?" — rather than guessing and generating a bad draft.
+
+## Step 2 — Discover the template
+
+Look, in order:
+
+1. `docs/issue-template.md` in the project root.
+2. `.github/ISSUE_TEMPLATE/*.md` (pick the closest match to intent, or ask
+   if multiple look relevant).
+3. Nothing found → use the amos default below.
+
+Read the file. Follow its section headers verbatim. Don't invent new sections.
+
+### Amos default template
+
+```markdown
+## Description
+One short paragraph, written for an AI agent with no prior context.
+
+## Context
+Why this matters. Constraints, prior work, related discussion.
+
+## Exit criteria
+- [ ] <concrete deliverable>
+- [ ] <concrete deliverable>
+
+## Tests / validation
+- [ ] <inline test case>  OR  "Blocked by #N (test harness)"
+
+## Related
+- Milestone: <name>
+- See also: #N, #M
+```
+
+**Do NOT** put `Blocked by:` / `Blocks:` in the `Related` section — those are
+set via native GitHub relationships, not text. The `Related` section is for
+human context only ("see also", "context from #N", etc.).
+
+## Step 3 — Draft title + body
+
+Title rules:
+
+- **Conventional-commit prefix** where appropriate: `fix(python): ...`,
+  `feat(adapter): ...`, `chore(ci): ...`. Match the project's existing title
+  style — scan `gh issue list --limit 20 --state all --json title` if unsure.
+- Under 70 characters.
+- No trailing period.
+- Describes *what breaks* or *what ships*, not *how to fix it*.
+
+Body rules:
+
+- Fill every template section. Empty = drift.
+- Be terse. One short paragraph per section. Use lists where the template has them.
+- Write for an agent walking in cold, not for someone who saw the conversation.
+- If the intent came from a debugging thread, copy the exact error strings / VUIDs
+  / stack traces into `Context` — they're search-fuel for future lookups.
+
+## Step 4 — Infer milestone (with AskUserQuestion fallback)
+
+```bash
+"$HOME/.local/bin/amos" milestones --json --dir <project-root> | jq '.milestones[] | .title'
+```
+
+Match against the draft's title + body keywords + label affinity (e.g. `python`
+label → "Polyglot SDK Realignment" milestone on streamlib). **Confidence tiers:**
+
+- **High** — one milestone's title or scope contains a core concept from the
+  draft (exact word match on a distinctive term). Use it.
+- **Medium / low / ambiguous** — two or more candidates look plausible, or
+  none clearly match. Call `AskUserQuestion`:
+
+  ```
+  Which milestone should this go in?
+  [ 1 ] <candidate 1 title>
+  [ 2 ] <candidate 2 title>
+  [ 3 ] <candidate 3 title>
+  [ 4 ] None of these / I'll tell you
+  [ 5 ] No milestone (orphan)
+  ```
+
+  If the user picks "I'll tell you", ask for the title and validate it against
+  the `amos milestones` list.
+
+## Step 5 — Infer labels
+
+```bash
+gh label list --repo <owner>/<repo> --limit 100 --json name,description
+```
+
+Apply labels whose name or description matches draft keywords:
+
+- `bug` if the draft describes broken behavior (not "rough edge" or "nice to have")
+- Platform tags (`linux`, `macos`, `polyglot`) if the draft mentions them
+- Scope tags (`ci`, `docs`, `research`) for obvious fits
+
+If unsure for a label, skip it. Labels are cheap to add after filing; wrong
+labels cause routing confusion.
+
+## Step 6 — Detect relationships
+
+Scan the user's intent + conversation for explicit signals:
+
+- "this blocks #322", "depends on #310", "after #300 lands"
+- "sub-issue of #319", "part of the #319 umbrella"
+- "related to #302" → goes in the `Related` section as plain text, not a native
+  relationship
+
+For each explicit mention, turn into a structured edge:
+
+```json
+{
+  "blocked_by": ["@github:<owner>/<repo>#310"],
+  "blocks": ["@github:<owner>/<repo>#322"],
+  "sub_issue_of": "@github:<owner>/<repo>#319"
+}
+```
+
+If the intent implies a dependency but doesn't say the direction clearly, ask
+via `AskUserQuestion` — wrong-direction edges are painful to unwind.
+
+## Step 7 — Approval gate (mandatory)
+
+Present the draft in full, then `AskUserQuestion`:
+
+```
+Ready to file this issue?
+
+Title:      <title>
+Milestone:  <milestone or "none">
+Labels:     <label1, label2, ...>
+Blocked by: <list, or "none">
+Blocks:     <list, or "none">
+Parent:     <sub_issue_of, or "none">
+
+---
+<body>
+---
+
+[ 1 ] File it as shown
+[ 2 ] Change the title
+[ 3 ] Change the milestone
+[ 4 ] Edit the body
+[ 5 ] Fix the relationships
+[ 6 ] Cancel
+```
+
+If the user picks anything but "File it as shown", iterate on the relevant
+field and re-show the full draft before asking again.
+
+## Step 8 — Execute atomically
+
+Write the approved draft to a temp JSON spec, then hand off to the binary:
+
+```bash
+cat > /tmp/amos-spec.json <<'JSON'
+{
+  "title": "fix(python): ...",
+  "body": "## Description\n...",
+  "milestone": "Polyglot SDK Realignment",
+  "labels": ["bug", "polyglot"],
+  "blocked_by": ["@github:tatolab/streamlib#322"],
+  "blocks": [],
+  "sub_issue_of": null
+}
+JSON
+
+"$HOME/.local/bin/amos" issue-create --spec /tmp/amos-spec.json --dir <project-root>
+rm /tmp/amos-spec.json
+```
+
+The binary creates the issue, applies the milestone + labels, then sets every
+native relationship in one pass. On success it prints `amos: created
+@github:<owner>/<repo>#<N> — <url>`.
+
+If any relationships failed to apply (non-existent target, API hiccup), the
+binary reports them to stderr — the issue is still created; re-run `amos
+sync-edges` or file a fix-up.
+
+## Step 9 — Report back
+
+Tell the user, in English:
+
+- Issue number + URL
+- Milestone, labels
+- Relationships created
+- Anything that needed a retry
+
+Don't summarize the body back at the user — they already approved it.
+
+## Common mistakes to avoid
+
+- **Don't** put `Blocked by: #N` text in the body's `Related` section when you
+  also added the native relationship. Native edges only. The `Related` section
+  is for free-text context.
+- **Don't** skip the approval gate even if the draft feels obviously right.
+  Users trust this pattern because it's predictable.
+- **Don't** invent a milestone that doesn't exist. Validate every `milestone:`
+  value against `amos milestones` before handing to the binary.
+- **Don't** hardcode a repo. The binary auto-detects from the scan root's git
+  remote; pass `--dir <project-root>` so it picks the right one.
+- **Don't** create a local plan file. AI-specific notes belong in the issue
+  body. The plan-file path is deprecated for new issues.

--- a/.claude/skills/amos-file/SKILL.md
+++ b/.claude/skills/amos-file/SKILL.md
@@ -164,14 +164,31 @@ labels cause routing confusion.
 
 ## Step 6 — Detect relationships
 
-Scan the user's intent + conversation for explicit signals:
+**Only four relationship types go into native GitHub relations.** If a
+reference doesn't fit one of these, it's free-text context — don't try
+to force it into a native edge.
 
-- "this blocks #322", "depends on #310", "after #300 lands"
-- "sub-issue of #319", "part of the #319 umbrella"
-- "related to #302" → goes in the `Related` section as plain text, not a native
-  relationship
+| Intent | Native relation | Pattern to match |
+| --- | --- | --- |
+| A can't start until B is done | `blocked_by` on A | "blocked by #N", "depends on #N", "waits on #N", "after #N lands" |
+| A must land before B can start | `blocks` on A | "this blocks #N", "gates #N", "prerequisite for #N" |
+| A is a concrete child under umbrella B | `sub_issue_of` on A | "sub-issue of #N", "part of the #N umbrella", "child of #N", "Parent: #N" |
+| A is the same issue as B | `duplicate` of (not yet supported by amos) | "duplicate of #N", "duplicates #N" |
 
-For each explicit mention, turn into a structured edge:
+**Everything else stays as free-text in the `Related` section** — or
+gets dropped entirely. Phrases like "exposed by", "surfaced by",
+"follow-up to", "see also", "related to", "in the same cluster as"
+are soft references with no GitHub-native equivalent. If they don't
+affect work order, don't call them out at all.
+
+Rule of thumb: **if a reference doesn't fit the table above, it's
+probably not a relationship worth calling out.** The value of a native
+relation is that `amos next` / `amos blocked` will respect it and
+order work correctly. Free-text refs are just noise the next agent
+has to mentally filter.
+
+For each matching reference, turn it into a structured edge in the
+spec:
 
 ```json
 {
@@ -181,8 +198,9 @@ For each explicit mention, turn into a structured edge:
 }
 ```
 
-If the intent implies a dependency but doesn't say the direction clearly, ask
-via `AskUserQuestion` — wrong-direction edges are painful to unwind.
+If the intent implies a dependency but doesn't say the direction
+clearly, ask via `AskUserQuestion` — wrong-direction edges are painful
+to unwind (they create cycle errors on any later correction).
 
 ## Step 7 — Approval gate (mandatory)
 

--- a/.claude/skills/amos-next/SKILL.md
+++ b/.claude/skills/amos-next/SKILL.md
@@ -156,6 +156,31 @@ note that CI must catch it.
 
 ## Step 7 — Push + open PR
 
+Before creating the PR, collect **every** issue the branch addresses — not just
+the primary one from Step 1 — so GitHub auto-closes all of them on merge.
+
+### Detect addressed issues
+
+Gather the set from three sources, then dedup:
+
+1. **Primary issue** from Step 1.
+2. **Commit trailers** — scan this branch's commits for explicit close
+   keywords:
+   ```bash
+   git log main..HEAD --pretty=%B \
+     | grep -oiE '(closes|fixes|resolves) +#[0-9]+' \
+     | grep -oE '#[0-9]+' | sort -u
+   ```
+3. **Branch name** — if the branch name ends in `-<N>` (e.g.
+   `fix/api-server-config-388`), treat that as a primary.
+
+If a commit mentions an issue without a close keyword (just `#N`), that's a
+reference, not a closing link — don't auto-close it. If you're unsure whether
+an issue should close with this PR, leave it out and file a follow-up; wrong
+auto-closes are annoying to reverse.
+
+### Create the PR
+
 ```bash
 git push -u origin <branch-name>
 gh pr create --title "<conventional-commit title>" --body "$(cat <<'EOF'
@@ -163,7 +188,9 @@ gh pr create --title "<conventional-commit title>" --body "$(cat <<'EOF'
 <1–3 bullets>
 
 ## Closes
-Closes #<N>
+Closes #<N1>
+Closes #<N2>
+Closes #<N3>
 
 ## Exit criteria
 <copied from issue body, checked>
@@ -178,6 +205,9 @@ Closes #<N>
 EOF
 )"
 ```
+
+One `Closes #N` per line — GitHub's auto-close parser only fires on that
+exact shape. `Closes #1, #2, #3` on one line does NOT work.
 
 ## Step 8 — Report back
 

--- a/.claude/skills/amos/SKILL.md
+++ b/.claude/skills/amos/SKILL.md
@@ -10,50 +10,66 @@ description: >
 
 # Amos
 
-Amos is a CLI preprocessor over markdown files. Each file with `whoami: amos` frontmatter is a
-**node** in a dependency graph. Typical use: project plans, tickets, tasks, or work items that
-span external trackers (GitHub issues, etc.) with `down:` / `up:` edges between them.
+Amos is a CLI preprocessor that overlays a local markdown cache on the adapter's source of truth
+(GitHub issues today, other trackers via adapter). The adapter is authoritative for what issues
+exist, their state, milestone, and dependency edges. Local plan files are optional overlays that
+hold AI-specific notes or pre-GA edges not yet pushed upstream.
+
+Read: the DAG is fetched fresh from GitHub on every `amos` call. Issues appear whether or not
+they have a local plan file.
 
 ## The canonical name rule — NON-NEGOTIABLE
 
-Every node has an identifier in its `name:` field. Use the adapter-qualified form:
+Every node — whether materialized from GitHub directly or from a local plan file — is identified
+by an adapter-qualified name:
 
-```yaml
-name: "@github:<owner>/<repo>#<issue-number>"
+```
+@github:<owner>/<repo>#<issue-number>
 ```
 
-e.g. `name: "@github:tatolab/streamlib#326"`.
+e.g. `@github:tatolab/streamlib#326`. This is the string amos uses for every edge lookup; every
+`blocked_by:` / `blocks:` / `related_to:` reference uses it.
 
-**Never put human-readable text in `name:`.** `name:` is a stable identifier used for edge
-resolution. Every `down:` and `up:` edge references another node by this string, so edits to it
-silently break the DAG. Put titles, summaries, and routing hints in `description:` (free-form).
+## Dependency edges: GitHub native > plan file
 
-If you see a node with a free-text name (e.g. `name: "Learning doc: ..."`), that's drift and
-should be fixed — rename to the canonical form and move the free text into `description:`.
+GitHub's issue UI now exposes **five typed relationships** (blocked-by, blocks, parent,
+sub-issue, duplicate). Amos reads these natively via GraphQL (`blockedBy`, `blocking`,
+`parent`, `subIssues`). Any edge declared through the GitHub UI or REST/GraphQL API is
+visible to `amos graph` / `next` / `blocked` with zero local state.
 
-## Node file format
+**Plan files are no longer required to declare edges.** The old `blocked_by:` / `blocks:`
+frontmatter fields still work — they're merged with GitHub's native edges — but adding new
+edges should go through GitHub's UI or `gh api graphql` so the dependency graph stays in one
+place.
+
+To migrate a project's existing plan-file edges to GitHub native:
+
+```bash
+"$HOME/.local/bin/amos" sync-edges --dry-run --dir <project-root>   # preview
+"$HOME/.local/bin/amos" sync-edges --dir <project-root>             # apply
+```
+
+The operation is idempotent; re-running is safe.
+
+## Optional plan file format
+
+Only create a plan file when you have AI-specific notes that shouldn't live in the public GitHub
+issue body. The file format is:
 
 ```markdown
 ---
 whoami: amos
 name: "@github:<owner>/<repo>#<N>"
-status: pending | in-progress | completed
 description: "<short routing hint — free-form>"
-github_issue: <N>
-dependencies:
-  - "down:@github:<owner>/<repo>#<M>"   # this node blocks M
-  - "up:@github:<owner>/<repo>#<K>"     # this node waits on K
+# blocked_by / blocks are optional — prefer setting these in GitHub's UI instead.
 adapters:
   github: builtin
 ---
 
-@github:<owner>/<repo>#<N>
-
-Local agent instructions below the adapter reference. These stay local even when
-the remote issue body is resolved by the adapter.
+Local agent instructions here. Kept local so they don't clutter the public issue.
 ```
 
-Filename convention: `<N>-<short-kebab-slug>.md` under `plan/` (or wherever amos scans).
+Filename convention: `<N>-<short-kebab-slug>.md` under `plan/`.
 
 ## Sub-skill routing
 

--- a/.claude/skills/amos/SKILL.md
+++ b/.claude/skills/amos/SKILL.md
@@ -73,13 +73,23 @@ Filename convention: `<N>-<short-kebab-slug>.md` under `plan/`.
 
 ## Sub-skill routing
 
+- **amos-file** — file a new GitHub issue from short natural-language intent. Handles template
+  discovery, milestone inference, relationship setup, and atomic creation. Use whenever the
+  user says "file this", "open a ticket for X", "create an issue", or confirms a "want me to
+  file this?" prompt.
 - **amos-graph** — print the full dependency tree. Use for "what's open", "what's next",
   "what's blocked", "show me the roadmap", orientation queries.
+- **amos-next** — pick up and execute the next ready-to-start issue in the focused milestone,
+  end-to-end (branch, work, test, PR).
+- **amos-focus** — set or switch the current milestone focus.
 - **amos-show** — resolve a single node to full content including `@`-references. Use for
   "tell me about #N".
-- **amos-create** — scaffold a new node (user-invoked via `/amos-create`).
 - **amos-notify** — post a message to a node's source system, e.g. GitHub issue comment
   (user-invoked via `/amos-notify`).
+
+The older **amos-create** skill scaffolded a plan file for an already-existing GitHub issue.
+Since plan files are now optional and rarely needed, prefer **amos-file** for new issues and
+skip the plan file entirely.
 
 ## The CLI
 

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -66,6 +66,34 @@ pub enum RelationshipKind {
     SubIssueOf,
 }
 
+/// Declarative issue spec passed to `create_issue`. Lets the `amos-file`
+/// skill produce a draft, show it to the user, and hand off a single
+/// structured payload for atomic creation.
+#[derive(Debug, Clone, Default)]
+pub struct IssueSpec {
+    pub title: String,
+    pub body: String,
+    pub milestone: Option<String>,
+    pub labels: Vec<String>,
+    /// References of nodes this one is blocked by (canonical names).
+    pub blocked_by: Vec<String>,
+    /// References this one blocks.
+    pub blocks: Vec<String>,
+    /// If set, the new issue is a sub-issue of this one.
+    pub sub_issue_of: Option<String>,
+}
+
+/// Result of a successful issue creation.
+#[derive(Debug, Clone)]
+pub struct CreatedIssue {
+    /// Canonical amos name (e.g. `@github:tatolab/streamlib#395`).
+    pub name: String,
+    /// Tracker-specific issue number.
+    pub number: u64,
+    /// URL users can click to view the issue.
+    pub url: String,
+}
+
 /// Adapter trait — resolves URIs within a registered scheme.
 ///
 /// An adapter handles a URI scheme (e.g. `gh:`, `jira:`, `linear:`).
@@ -125,6 +153,16 @@ pub trait Adapter: Send + Sync {
         _kind: RelationshipKind,
     ) -> Result<()> {
         bail!("adapter does not support creating relationships")
+    }
+
+    /// Create a new issue/task in the backing system. Returns the canonical
+    /// amos name + tracker-specific number + clickable URL. Milestone,
+    /// labels, and relationships in the spec are applied atomically — if
+    /// any relationship fails, creation is still reported as successful but
+    /// the error is attached to the partial-failure list returned by the
+    /// caller.
+    fn create_issue(&self, _spec: &IssueSpec) -> Result<CreatedIssue> {
+        bail!("adapter does not support creating issues")
     }
 }
 
@@ -225,6 +263,16 @@ impl AdapterRegistry {
             }
         }
         out
+    }
+
+    /// Create a new issue via the named adapter scheme (e.g. "github"). The
+    /// caller decides which scheme to use — there's no inference from the
+    /// issue body, since a brand-new issue has no canonical name yet.
+    pub fn create_issue(&self, scheme: &str, spec: &IssueSpec) -> Result<CreatedIssue> {
+        let Some(adapter) = self.adapters.get(scheme) else {
+            bail!("no adapter registered for scheme '{}'", scheme);
+        };
+        adapter.create_issue(spec)
     }
 
     /// Add a native relationship via the adapter that owns `from`.

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -75,6 +75,10 @@ pub struct IssueSpec {
     pub body: String,
     pub milestone: Option<String>,
     pub labels: Vec<String>,
+    /// GitHub issue type — e.g. "Bug", "Feature", "Task". Case-insensitive
+    /// match against the repo's configured issue types. `None` leaves the
+    /// type unset.
+    pub issue_type: Option<String>,
     /// References of nodes this one is blocked by (canonical names).
     pub blocked_by: Vec<String>,
     /// References this one blocks.

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use std::collections::HashMap;
 
 /// Resolved fields from an adapter. Each field is optional —
@@ -13,6 +13,57 @@ pub struct ResourceFields {
     /// reads the facts and reasons about them.
     /// Examples: {"state": "CLOSED", "labels": "bug, priority-high"}
     pub facts: HashMap<String, String>,
+}
+
+/// A "node view" materialized directly from an adapter's backing system — e.g.
+/// a GitHub issue enumerated from a milestone. Lets amos see issues that don't
+/// have a local plan file.
+///
+/// Adapters emit these; `main.rs` merges them with local parsed nodes to build
+/// a complete DAG. Local nodes always win for AI-specific fields (body,
+/// context, labels_local); the adapter wins for state + native relationship
+/// edges.
+#[derive(Debug, Clone, Default)]
+pub struct AdapterNode {
+    /// Canonical amos name (e.g. `@github:tatolab/streamlib#388`).
+    pub name: String,
+    pub title: String,
+    /// Raw facts — state, milestone, labels (comma-joined). Same shape as
+    /// `ResourceFields::facts`.
+    pub facts: HashMap<String, String>,
+    /// Canonical names of nodes blocking this one (upstream → this is blocked
+    /// by these).
+    pub blocked_by: Vec<String>,
+    /// Canonical names of nodes this one blocks (downstream).
+    pub blocks: Vec<String>,
+    /// Parent issue (GitHub sub-issue hierarchy).
+    pub parent: Option<String>,
+    /// Child issues (GitHub sub-issues).
+    pub sub_issues: Vec<String>,
+}
+
+/// Summary of a milestone pulled directly from the adapter. Counts are
+/// authoritative — they reflect every issue in the milestone, not just ones
+/// with a local plan file.
+#[derive(Debug, Clone)]
+pub struct MilestoneInfo {
+    pub title: String,
+    pub state: String,
+    pub open_count: usize,
+    pub closed_count: usize,
+}
+
+/// Kinds of native relationships amos knows how to create. Adapters may
+/// support a subset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelationshipKind {
+    /// `from` is blocked by `to` (GitHub: addBlockedBy).
+    BlockedBy,
+    /// `from` blocks `to` (inverse of BlockedBy — adapter may implement via
+    /// the reverse mutation).
+    Blocks,
+    /// `from` is a sub-issue of `to` (GitHub: addSubIssue with parent = `to`).
+    SubIssueOf,
 }
 
 /// Adapter trait — resolves URIs within a registered scheme.
@@ -46,6 +97,34 @@ pub trait Adapter: Send + Sync {
     /// Default is a no-op — adapters that support write-back override this.
     fn notify(&self, _reference: &str, _message: &str) -> Result<()> {
         Ok(())
+    }
+
+    /// List every milestone this adapter knows about. Lets `amos milestones`
+    /// report accurate counts regardless of which issues have local plan
+    /// files. Default is empty — adapters that don't model milestones return
+    /// nothing.
+    fn list_milestones(&self) -> Result<Vec<MilestoneInfo>> {
+        Ok(Vec::new())
+    }
+
+    /// Enumerate all nodes in a milestone, including native relationship
+    /// edges (GitHub's typed `blockedBy` / `blocking` / `parent` / `subIssues`
+    /// fields). Default is empty.
+    fn list_nodes_in_milestone(&self, _milestone: &str) -> Result<Vec<AdapterNode>> {
+        Ok(Vec::new())
+    }
+
+    /// Create a native relationship between two references. `from` and `to`
+    /// are adapter-local references (not full URIs — the scheme prefix is
+    /// already stripped). Default errors — adapters that support write-back
+    /// override.
+    fn add_relationship(
+        &self,
+        _from: &str,
+        _to: &str,
+        _kind: RelationshipKind,
+    ) -> Result<()> {
+        bail!("adapter does not support creating relationships")
     }
 }
 
@@ -120,6 +199,60 @@ impl AdapterRegistry {
             }
         }
         Ok(all_results)
+    }
+
+    /// List every milestone across every registered adapter. Useful for
+    /// `amos milestones` — returns accurate counts from the source of truth,
+    /// not from whatever subset of issues has local plan files.
+    pub fn list_all_milestones(&self) -> Vec<MilestoneInfo> {
+        let mut out: Vec<MilestoneInfo> = Vec::new();
+        for adapter in self.adapters.values() {
+            match adapter.list_milestones() {
+                Ok(ms) => out.extend(ms),
+                Err(e) => eprintln!("amos: {} adapter milestone listing failed: {}", adapter.scheme(), e),
+            }
+        }
+        out
+    }
+
+    /// Enumerate all nodes in `milestone` from every adapter.
+    pub fn list_nodes_in_milestone(&self, milestone: &str) -> Vec<AdapterNode> {
+        let mut out: Vec<AdapterNode> = Vec::new();
+        for adapter in self.adapters.values() {
+            match adapter.list_nodes_in_milestone(milestone) {
+                Ok(ns) => out.extend(ns),
+                Err(e) => eprintln!("amos: {} adapter milestone enumeration failed: {}", adapter.scheme(), e),
+            }
+        }
+        out
+    }
+
+    /// Add a native relationship via the adapter that owns `from`.
+    pub fn add_relationship(
+        &self,
+        from: &str,
+        to: &str,
+        kind: RelationshipKind,
+    ) -> Result<()> {
+        let Some((scheme, from_ref)) = self.parse_uri(from) else {
+            bail!("'{}' is not a recognized adapter URI", from);
+        };
+        let Some(adapter) = self.adapters.get(scheme) else {
+            bail!("no adapter registered for scheme '{}'", scheme);
+        };
+        let to_ref = self
+            .parse_uri(to)
+            .and_then(|(target_scheme, target_ref)| {
+                (target_scheme == scheme).then_some(target_ref)
+            })
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "relationship targets must share a scheme: {} vs {}",
+                    from,
+                    to
+                )
+            })?;
+        adapter.add_relationship(from_ref, to_ref, kind)
     }
 
     /// Parse a string into (scheme, reference) if it looks like a URI.
@@ -211,5 +344,38 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert!(results.contains_key("@mock:a"));
         assert!(results.contains_key("@mock:b"));
+    }
+
+    #[test]
+    fn default_trait_methods_return_empty() {
+        // Adapters that don't override the new milestone/relationship
+        // methods should no-op cleanly, not error — keeps every non-GitHub
+        // adapter forward-compatible.
+        let adapter = MockAdapter;
+        assert!(adapter.list_milestones().unwrap().is_empty());
+        assert!(adapter.list_nodes_in_milestone("foo").unwrap().is_empty());
+        let err = adapter
+            .add_relationship("a", "b", RelationshipKind::BlockedBy)
+            .unwrap_err();
+        assert!(format!("{}", err).contains("does not support"));
+    }
+
+    #[test]
+    fn registry_list_all_milestones_aggregates_adapters() {
+        let mut registry = AdapterRegistry::new();
+        registry.register(Box::new(MockAdapter));
+        // The default MockAdapter returns empty, so the aggregate is empty.
+        assert!(registry.list_all_milestones().is_empty());
+    }
+
+    #[test]
+    fn registry_add_relationship_routes_by_scheme() {
+        let registry = AdapterRegistry::new();
+        // No mock adapter registered — routing should fail cleanly with a
+        // helpful message, not panic.
+        let err = registry
+            .add_relationship("@ghost:1", "@ghost:2", RelationshipKind::BlockedBy)
+            .unwrap_err();
+        assert!(format!("{}", err).contains("no adapter registered"));
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -98,4 +98,12 @@ pub enum Command {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Push every local `blocked_by:` / `blocks:` edge up to the adapter as a
+    /// native relationship (GitHub's typed issue dependencies). Idempotent —
+    /// edges already present upstream are skipped.
+    SyncEdges {
+        /// Show the plan without mutating the adapter.
+        #[arg(long)]
+        dry_run: bool,
+    },
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -106,4 +106,16 @@ pub enum Command {
         #[arg(long)]
         dry_run: bool,
     },
+    /// Create a new issue in the adapter's backing system from a JSON spec,
+    /// applying milestone, labels, and native relationships in one call.
+    /// The spec shape matches `IssueSpec` (see `amos --help issue create`
+    /// for the schema).
+    IssueCreate {
+        /// Adapter scheme. Default is "github".
+        #[arg(long, default_value = "github")]
+        scheme: String,
+        /// Path to JSON spec file. Use "-" (default) for stdin.
+        #[arg(long, default_value = "-")]
+        spec: String,
+    },
 }

--- a/src/gh_adapter.rs
+++ b/src/gh_adapter.rs
@@ -3,7 +3,9 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::process::Command;
 
-use crate::adapter::{Adapter, AdapterNode, MilestoneInfo, RelationshipKind, ResourceFields};
+use crate::adapter::{
+    Adapter, AdapterNode, CreatedIssue, IssueSpec, MilestoneInfo, RelationshipKind, ResourceFields,
+};
 use crate::url_adapter::download_to_cache;
 
 /// GitHub adapter — resolves `gh:` URIs via the `gh` CLI.
@@ -498,6 +500,13 @@ impl Adapter for GhAdapter {
         };
         add_relationship_graphql(repo, from_num, to_num, kind)
     }
+
+    fn create_issue(&self, spec: &IssueSpec) -> Result<CreatedIssue> {
+        let Some(repo) = self.default_repo.as_deref() else {
+            bail!("no default repo — run inside a git checkout or configure one");
+        };
+        create_issue_via_gh(repo, spec)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -850,6 +859,42 @@ fn split_repo(repo: &str) -> Result<(&str, &str)> {
         .ok_or_else(|| anyhow::anyhow!("malformed repo '{}', expected owner/name", repo))
 }
 
+/// Create a new GitHub issue via `gh issue create`. Applies title + body
+/// + milestone + labels in the same call; relationships are separate
+/// mutations the caller runs afterward.
+fn create_issue_via_gh(repo: &str, spec: &IssueSpec) -> Result<CreatedIssue> {
+    if spec.title.trim().is_empty() {
+        bail!("issue title is empty");
+    }
+    let mut cmd = Command::new("gh");
+    cmd.args(["issue", "create", "--repo", repo]);
+    cmd.args(["--title", &spec.title]);
+    cmd.args(["--body", &spec.body]);
+    if let Some(ms) = &spec.milestone {
+        cmd.args(["--milestone", ms]);
+    }
+    for label in &spec.labels {
+        cmd.args(["--label", label]);
+    }
+
+    let output = cmd.output().context("failed to spawn 'gh issue create'")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("gh issue create failed: {}", stderr.trim());
+    }
+    // gh prints the issue URL to stdout on success.
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let number = url
+        .rsplit_once('/')
+        .and_then(|(_, n)| n.parse::<u64>().ok())
+        .ok_or_else(|| anyhow::anyhow!("couldn't parse issue number from gh output: {}", url))?;
+    Ok(CreatedIssue {
+        name: format!("@github:{}#{}", repo, number),
+        number,
+        url,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -927,6 +972,17 @@ mod tests {
             node.facts.get("milestone").map(|s| s.as_str()),
             Some("Some Milestone")
         );
+    }
+
+    #[test]
+    fn create_issue_rejects_empty_title() {
+        let spec = IssueSpec {
+            title: "   ".to_string(),
+            body: "Some body".to_string(),
+            ..Default::default()
+        };
+        let err = create_issue_via_gh("tatolab/amos", &spec).unwrap_err();
+        assert!(format!("{}", err).contains("title is empty"));
     }
 
     #[test]

--- a/src/gh_adapter.rs
+++ b/src/gh_adapter.rs
@@ -860,8 +860,8 @@ fn split_repo(repo: &str) -> Result<(&str, &str)> {
 }
 
 /// Create a new GitHub issue via `gh issue create`. Applies title + body
-/// + milestone + labels in the same call; relationships are separate
-/// mutations the caller runs afterward.
+/// + milestone + labels in the same call; relationships + issue type are
+/// separate mutations the caller runs afterward.
 fn create_issue_via_gh(repo: &str, spec: &IssueSpec) -> Result<CreatedIssue> {
     if spec.title.trim().is_empty() {
         bail!("issue title is empty");
@@ -888,11 +888,82 @@ fn create_issue_via_gh(repo: &str, spec: &IssueSpec) -> Result<CreatedIssue> {
         .rsplit_once('/')
         .and_then(|(_, n)| n.parse::<u64>().ok())
         .ok_or_else(|| anyhow::anyhow!("couldn't parse issue number from gh output: {}", url))?;
+
+    if let Some(type_name) = &spec.issue_type {
+        set_issue_type_by_name(repo, number, type_name)?;
+    }
+
     Ok(CreatedIssue {
         name: format!("@github:{}#{}", repo, number),
         number,
         url,
     })
+}
+
+/// Apply a repository-level issue type (e.g. "Bug", "Feature", "Task") to
+/// an already-created issue. `gh issue create` doesn't support `--type`,
+/// so we set it via the `updateIssueIssueType` mutation.
+fn set_issue_type_by_name(repo: &str, number: u64, type_name: &str) -> Result<()> {
+    let issue_id = fetch_issue_node_id(repo, number)?;
+    let types = fetch_issue_types_graphql(repo)?;
+    let type_id = types
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case(type_name))
+        .map(|(_, id)| id.clone())
+        .ok_or_else(|| {
+            let available: Vec<&str> = types.iter().map(|(n, _)| n.as_str()).collect();
+            anyhow::anyhow!(
+                "issue type '{}' not configured on {} (available: {})",
+                type_name,
+                repo,
+                available.join(", ")
+            )
+        })?;
+    let query = r#"
+        mutation($issue: ID!, $type: ID!) {
+          updateIssueIssueType(input: {issueId: $issue, issueTypeId: $type}) {
+            issue { number }
+          }
+        }
+    "#;
+    run_graphql(query, &[("issue", &issue_id), ("type", &type_id)])?;
+    Ok(())
+}
+
+/// Fetch the repository's configured issue types. Returns [(name, id)]
+/// pairs. Repo admins manage the list — amos doesn't create types itself.
+fn fetch_issue_types_graphql(repo: &str) -> Result<Vec<(String, String)>> {
+    let (owner, name) = split_repo(repo)?;
+    let query = r#"
+        query($owner: String!, $name: String!) {
+          repository(owner: $owner, name: $name) {
+            issueTypes(first: 50) { nodes { id name } }
+          }
+        }
+    "#;
+    let response = run_graphql(query, &[("owner", owner), ("name", name)])?;
+    let nodes = response
+        .pointer("/data/repository/issueTypes/nodes")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let mut out = Vec::with_capacity(nodes.len());
+    for node in nodes {
+        let name = node
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let id = node
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        if !name.is_empty() && !id.is_empty() {
+            out.push((name, id));
+        }
+    }
+    Ok(out)
 }
 
 #[cfg(test)]

--- a/src/gh_adapter.rs
+++ b/src/gh_adapter.rs
@@ -1,8 +1,9 @@
 use anyhow::{bail, Context, Result};
 use std::collections::HashMap;
+use std::path::Path;
 use std::process::Command;
 
-use crate::adapter::{Adapter, ResourceFields};
+use crate::adapter::{Adapter, AdapterNode, MilestoneInfo, RelationshipKind, ResourceFields};
 use crate::url_adapter::download_to_cache;
 
 /// GitHub adapter — resolves `gh:` URIs via the `gh` CLI.
@@ -21,6 +22,21 @@ pub struct GhAdapter {
 impl GhAdapter {
     pub fn new(default_repo: Option<String>) -> Self {
         GhAdapter { default_repo }
+    }
+
+    /// Construct a `GhAdapter` whose default repo is inferred from the scan
+    /// root's git remote. Falls back to `None` if the directory isn't a git
+    /// checkout or the remote doesn't point at github.com.
+    pub fn with_detected_repo(scan_root: &Path) -> Self {
+        GhAdapter {
+            default_repo: detect_github_repo(scan_root),
+        }
+    }
+
+    /// Read the effective default repo (from the arg passed to `new()` or
+    /// auto-detected from the scan root).
+    pub fn default_repo(&self) -> Option<&str> {
+        self.default_repo.as_deref()
     }
 
     fn parse_ref(&self, reference: &str) -> Result<(Option<String>, u64)> {
@@ -446,6 +462,486 @@ impl Adapter for GhAdapter {
         }
 
         Ok(results)
+    }
+
+    fn list_milestones(&self) -> Result<Vec<MilestoneInfo>> {
+        let Some(repo) = self.default_repo.as_deref() else {
+            return Ok(Vec::new());
+        };
+        fetch_milestones_graphql(repo)
+    }
+
+    fn list_nodes_in_milestone(&self, milestone: &str) -> Result<Vec<AdapterNode>> {
+        let Some(repo) = self.default_repo.as_deref() else {
+            return Ok(Vec::new());
+        };
+        fetch_milestone_issues_graphql(repo, milestone)
+    }
+
+    fn add_relationship(
+        &self,
+        from: &str,
+        to: &str,
+        kind: RelationshipKind,
+    ) -> Result<()> {
+        let (from_repo, from_num) = self.parse_ref(from)?;
+        let (to_repo, to_num) = self.parse_ref(to)?;
+        if from_repo != to_repo {
+            bail!(
+                "relationships across different repos aren't supported: {} → {}",
+                from,
+                to
+            );
+        }
+        let Some(repo) = from_repo.as_deref().or(self.default_repo.as_deref()) else {
+            bail!("no default repo — pass --repo or run inside a git checkout");
+        };
+        add_relationship_graphql(repo, from_num, to_num, kind)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GraphQL helpers
+//
+// The GhAdapter talks to the REST API for single-issue view/comment and the
+// paginated issue list, but the relationship fields (`blockedBy`, `blocking`,
+// `parent`, `subIssues`) and the mutation endpoints for native relationships
+// live in GraphQL only. The helpers below are intentionally stateless — they
+// shell out to `gh api graphql`, the same auth path the REST calls use.
+// ---------------------------------------------------------------------------
+
+/// Detect a GitHub repo (`owner/name`) from the directory's git remote.
+/// Returns `None` if the directory isn't a git checkout, has no remote, or
+/// the remote doesn't point at github.com.
+fn detect_github_repo(dir: &Path) -> Option<String> {
+    let output = Command::new("git")
+        .args(["-C", dir.to_str()?, "remote", "get-url", "origin"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    parse_github_remote(&url)
+}
+
+/// Extract `owner/name` from typical github.com remote URL shapes:
+/// - `https://github.com/owner/name.git`
+/// - `git@github.com:owner/name.git`
+/// - `ssh://git@github.com/owner/name.git`
+fn parse_github_remote(url: &str) -> Option<String> {
+    let stripped = url
+        .strip_prefix("https://github.com/")
+        .or_else(|| url.strip_prefix("http://github.com/"))
+        .or_else(|| url.strip_prefix("git@github.com:"))
+        .or_else(|| url.strip_prefix("ssh://git@github.com/"))?;
+    let without_suffix = stripped.strip_suffix(".git").unwrap_or(stripped);
+    let parts: Vec<&str> = without_suffix.splitn(3, '/').collect();
+    if parts.len() < 2 || parts[0].is_empty() || parts[1].is_empty() {
+        return None;
+    }
+    Some(format!("{}/{}", parts[0], parts[1]))
+}
+
+/// Run a `gh api graphql` query and return the parsed JSON response. Query
+/// variables are passed as `-F key=value`.
+fn run_graphql(query: &str, variables: &[(&str, &str)]) -> Result<serde_json::Value> {
+    let mut cmd = Command::new("gh");
+    cmd.args(["api", "graphql", "-f", &format!("query={}", query)]);
+    for (k, v) in variables {
+        cmd.args(["-F", &format!("{}={}", k, v)]);
+    }
+    let output = cmd
+        .output()
+        .context("failed to run 'gh api graphql' — is gh CLI installed?")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("gh api graphql failed: {}", stderr.trim());
+    }
+    let parsed: serde_json::Value =
+        serde_json::from_slice(&output.stdout).context("parsing graphql JSON response")?;
+    if let Some(errors) = parsed.get("errors") {
+        bail!("graphql errors: {}", errors);
+    }
+    Ok(parsed)
+}
+
+fn fetch_milestones_graphql(repo: &str) -> Result<Vec<MilestoneInfo>> {
+    let (owner, name) = split_repo(repo)?;
+    let query = r#"
+        query($owner: String!, $name: String!) {
+          repository(owner: $owner, name: $name) {
+            milestones(first: 100, orderBy: {field: NUMBER, direction: ASC}) {
+              nodes {
+                title
+                state
+                openIssues: issues(states: OPEN) { totalCount }
+                closedIssues: issues(states: CLOSED) { totalCount }
+              }
+            }
+          }
+        }
+    "#;
+    let response = run_graphql(query, &[("owner", owner), ("name", name)])?;
+    let nodes = response
+        .pointer("/data/repository/milestones/nodes")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let mut out = Vec::with_capacity(nodes.len());
+    for node in nodes {
+        let title = node
+            .get("title")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        if title.is_empty() {
+            continue;
+        }
+        let state = node
+            .get("state")
+            .and_then(|v| v.as_str())
+            .unwrap_or("OPEN")
+            .to_string();
+        let open_count = node
+            .pointer("/openIssues/totalCount")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+        let closed_count = node
+            .pointer("/closedIssues/totalCount")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as usize;
+        out.push(MilestoneInfo {
+            title,
+            state,
+            open_count,
+            closed_count,
+        });
+    }
+    Ok(out)
+}
+
+fn fetch_milestone_issues_graphql(repo: &str, milestone_title: &str) -> Result<Vec<AdapterNode>> {
+    let (owner, name) = split_repo(repo)?;
+    // Pagination: we ask for up to 100 issues per page and re-query until
+    // `hasNextPage` is false.
+    let query = r#"
+        query($owner: String!, $name: String!, $milestone: String!, $cursor: String) {
+          repository(owner: $owner, name: $name) {
+            milestones(query: $milestone, first: 10) {
+              nodes {
+                title
+                issues(first: 100, after: $cursor, states: [OPEN, CLOSED]) {
+                  pageInfo { hasNextPage endCursor }
+                  nodes {
+                    number title state
+                    labels(first: 20) { nodes { name } }
+                    milestone { title }
+                    blockedBy(first: 50) { nodes { number } }
+                    blocking(first: 50) { nodes { number } }
+                    parent { number }
+                    subIssues(first: 50) { nodes { number } }
+                  }
+                }
+              }
+            }
+          }
+        }
+    "#;
+
+    let mut cursor: Option<String> = None;
+    let mut out: Vec<AdapterNode> = Vec::new();
+    loop {
+        let cursor_arg = cursor.as_deref().unwrap_or("");
+        let mut vars: Vec<(&str, &str)> = vec![
+            ("owner", owner),
+            ("name", name),
+            ("milestone", milestone_title),
+        ];
+        if !cursor_arg.is_empty() {
+            vars.push(("cursor", cursor_arg));
+        }
+        let response = run_graphql(query, &vars)?;
+        // The `milestones(query:)` search can return multiple partial-title
+        // matches; filter to exact title only.
+        let milestones = response
+            .pointer("/data/repository/milestones/nodes")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        let Some(milestone) = milestones
+            .iter()
+            .find(|m| m.get("title").and_then(|v| v.as_str()) == Some(milestone_title))
+        else {
+            break;
+        };
+        let issues_obj = milestone
+            .pointer("/issues")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        let issue_nodes = issues_obj
+            .pointer("/nodes")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default();
+        for issue in issue_nodes {
+            out.push(issue_json_to_adapter_node(&issue, repo));
+        }
+        let has_next = issues_obj
+            .pointer("/pageInfo/hasNextPage")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if !has_next {
+            break;
+        }
+        cursor = issues_obj
+            .pointer("/pageInfo/endCursor")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        if cursor.is_none() {
+            break;
+        }
+    }
+
+    Ok(out)
+}
+
+fn issue_json_to_adapter_node(issue: &serde_json::Value, repo: &str) -> AdapterNode {
+    let number = issue.get("number").and_then(|v| v.as_u64()).unwrap_or(0);
+    let title = issue
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let state = issue
+        .get("state")
+        .and_then(|v| v.as_str())
+        .unwrap_or("OPEN")
+        .to_string();
+    let labels: Vec<String> = issue
+        .pointer("/labels/nodes")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|l| l.get("name").and_then(|v| v.as_str()).map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    let milestone = issue
+        .pointer("/milestone/title")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let extract_numbers = |path: &str| -> Vec<String> {
+        issue
+            .pointer(path)
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|n| n.get("number").and_then(|v| v.as_u64()))
+                    .map(|n| format!("@github:{}#{}", repo, n))
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+
+    let blocked_by = extract_numbers("/blockedBy/nodes");
+    let blocks = extract_numbers("/blocking/nodes");
+    let sub_issues = extract_numbers("/subIssues/nodes");
+    let parent = issue
+        .pointer("/parent/number")
+        .and_then(|v| v.as_u64())
+        .map(|n| format!("@github:{}#{}", repo, n));
+
+    let mut facts: HashMap<String, String> = HashMap::new();
+    facts.insert("state".to_string(), state);
+    if !labels.is_empty() {
+        facts.insert("labels".to_string(), labels.join(", "));
+    }
+    if let Some(ms) = milestone {
+        facts.insert("milestone".to_string(), ms);
+    }
+
+    AdapterNode {
+        name: format!("@github:{}#{}", repo, number),
+        title,
+        facts,
+        blocked_by,
+        blocks,
+        parent,
+        sub_issues,
+    }
+}
+
+/// Look up an issue's GraphQL node ID. Required for the relationship
+/// mutations — they take opaque IDs, not numbers.
+fn fetch_issue_node_id(repo: &str, number: u64) -> Result<String> {
+    let (owner, name) = split_repo(repo)?;
+    let query = r#"
+        query($owner: String!, $name: String!, $number: Int!) {
+          repository(owner: $owner, name: $name) {
+            issue(number: $number) { id }
+          }
+        }
+    "#;
+    let num_str = number.to_string();
+    let vars = [("owner", owner), ("name", name), ("number", num_str.as_str())];
+    // `-F` stringifies numbers, which is what GraphQL's Int scalar accepts
+    // over the CLI. (The server coerces.)
+    let response = run_graphql(query, &vars)?;
+    response
+        .pointer("/data/repository/issue/id")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .ok_or_else(|| anyhow::anyhow!("issue {}#{} not found", repo, number))
+}
+
+fn add_relationship_graphql(
+    repo: &str,
+    from_num: u64,
+    to_num: u64,
+    kind: RelationshipKind,
+) -> Result<()> {
+    let from_id = fetch_issue_node_id(repo, from_num)?;
+    let to_id = fetch_issue_node_id(repo, to_num)?;
+
+    match kind {
+        RelationshipKind::BlockedBy => {
+            // from is blocked by to — addBlockedBy takes issueId + blockingIssueId
+            let query = r#"
+                mutation($issue: ID!, $blocking: ID!) {
+                  addBlockedBy(input: {issueId: $issue, blockingIssueId: $blocking}) {
+                    issue { number }
+                  }
+                }
+            "#;
+            run_graphql(query, &[("issue", &from_id), ("blocking", &to_id)])?;
+        }
+        RelationshipKind::Blocks => {
+            // from blocks to — same mutation, flipped args
+            let query = r#"
+                mutation($issue: ID!, $blocking: ID!) {
+                  addBlockedBy(input: {issueId: $issue, blockingIssueId: $blocking}) {
+                    issue { number }
+                  }
+                }
+            "#;
+            run_graphql(query, &[("issue", &to_id), ("blocking", &from_id)])?;
+        }
+        RelationshipKind::SubIssueOf => {
+            // from is a sub-issue of to — addSubIssue takes parent (to) +
+            // child (from) as sub-issue.
+            let query = r#"
+                mutation($parent: ID!, $child: ID!) {
+                  addSubIssue(input: {issueId: $parent, subIssueId: $child}) {
+                    issue { number }
+                  }
+                }
+            "#;
+            run_graphql(query, &[("parent", &to_id), ("child", &from_id)])?;
+        }
+    }
+    Ok(())
+}
+
+fn split_repo(repo: &str) -> Result<(&str, &str)> {
+    repo.split_once('/')
+        .ok_or_else(|| anyhow::anyhow!("malformed repo '{}', expected owner/name", repo))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_https_remote() {
+        assert_eq!(
+            parse_github_remote("https://github.com/tatolab/amos.git"),
+            Some("tatolab/amos".to_string())
+        );
+        assert_eq!(
+            parse_github_remote("https://github.com/tatolab/amos"),
+            Some("tatolab/amos".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_ssh_remote() {
+        assert_eq!(
+            parse_github_remote("git@github.com:tatolab/amos.git"),
+            Some("tatolab/amos".to_string())
+        );
+        assert_eq!(
+            parse_github_remote("ssh://git@github.com/tatolab/amos.git"),
+            Some("tatolab/amos".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_non_github_remote_returns_none() {
+        assert_eq!(parse_github_remote("https://gitlab.com/foo/bar.git"), None);
+        assert_eq!(parse_github_remote("https://example.com/foo/bar.git"), None);
+    }
+
+    #[test]
+    fn parse_malformed_remote_returns_none() {
+        assert_eq!(parse_github_remote("not-a-url"), None);
+        assert_eq!(parse_github_remote("https://github.com/"), None);
+        assert_eq!(parse_github_remote("https://github.com/just-owner"), None);
+    }
+
+    #[test]
+    fn split_repo_handles_owner_name() {
+        let (owner, name) = split_repo("tatolab/amos").unwrap();
+        assert_eq!(owner, "tatolab");
+        assert_eq!(name, "amos");
+    }
+
+    #[test]
+    fn issue_json_to_adapter_node_extracts_relationships() {
+        let issue = serde_json::json!({
+            "number": 42,
+            "title": "Test issue",
+            "state": "OPEN",
+            "labels": { "nodes": [{"name": "bug"}, {"name": "linux"}] },
+            "milestone": { "title": "Some Milestone" },
+            "blockedBy": { "nodes": [{"number": 10}, {"number": 11}] },
+            "blocking": { "nodes": [{"number": 99}] },
+            "parent": { "number": 5 },
+            "subIssues": { "nodes": [{"number": 100}] }
+        });
+        let node = issue_json_to_adapter_node(&issue, "tatolab/amos");
+        assert_eq!(node.name, "@github:tatolab/amos#42");
+        assert_eq!(node.title, "Test issue");
+        assert_eq!(
+            node.blocked_by,
+            vec!["@github:tatolab/amos#10", "@github:tatolab/amos#11"]
+        );
+        assert_eq!(node.blocks, vec!["@github:tatolab/amos#99"]);
+        assert_eq!(node.parent.as_deref(), Some("@github:tatolab/amos#5"));
+        assert_eq!(node.sub_issues, vec!["@github:tatolab/amos#100"]);
+        assert_eq!(node.facts.get("state").map(|s| s.as_str()), Some("OPEN"));
+        assert_eq!(node.facts.get("labels").map(|s| s.as_str()), Some("bug, linux"));
+        assert_eq!(
+            node.facts.get("milestone").map(|s| s.as_str()),
+            Some("Some Milestone")
+        );
+    }
+
+    #[test]
+    fn issue_json_to_adapter_node_handles_empty_relationships() {
+        let issue = serde_json::json!({
+            "number": 1,
+            "title": "",
+            "state": "CLOSED"
+        });
+        let node = issue_json_to_adapter_node(&issue, "tatolab/amos");
+        assert!(node.blocked_by.is_empty());
+        assert!(node.blocks.is_empty());
+        assert!(node.sub_issues.is_empty());
+        assert!(node.parent.is_none());
+        assert_eq!(node.facts.get("state").map(|s| s.as_str()), Some("CLOSED"));
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use clap::Parser;
+use std::collections::HashSet;
 use std::path::PathBuf;
 
-use amos::adapter::AdapterRegistry;
+use amos::adapter::{AdapterNode, AdapterRegistry, RelationshipKind};
 use amos::adapter_pull;
 use amos::cli::{Cli, Command};
 use amos::dag::Dag;
@@ -11,7 +12,7 @@ use amos::file_adapter::FileAdapter;
 use amos::gh_adapter::GhAdapter;
 use amos::url_adapter::UrlAdapter;
 use amos::output;
-use amos::parser;
+use amos::parser::{self, Node};
 use amos::scanner;
 
 fn main() -> Result<()> {
@@ -111,19 +112,44 @@ fn main() -> Result<()> {
         _ => {}
     }
 
-    // Scan + parse
+    // Scan + parse. Scanning is optional for commands that only talk to the
+    // adapter — SyncEdges and Milestones (adapter-first) work without local
+    // nodes, but we still scan so status/focus helpers have a consistent
+    // scan_root to anchor on.
     let blocks = scanner::scan_directory(&scan_root)
         .with_context(|| format!("scanning {}", scan_root.display()))?;
 
-    if blocks.is_empty() {
+    let can_run_without_local_nodes = matches!(
+        &cli.command,
+        Some(Command::Milestones) | Some(Command::SyncEdges { .. })
+    );
+    if blocks.is_empty() && !can_run_without_local_nodes {
         eprintln!("No amos blocks found in {}", scan_root.display());
         std::process::exit(1);
     }
 
-    let nodes = parser::parse_blocks(&blocks).context("parsing amos blocks")?;
+    let local_nodes = parser::parse_blocks(&blocks).context("parsing amos blocks")?;
 
     // Build adapter registry
-    let registry = build_registry(&scan_root, &nodes);
+    let registry = build_registry(&scan_root, &local_nodes);
+
+    // If a milestone is focused, enumerate every issue in it from the adapter
+    // and merge with local plan files. This is what makes unplanned GitHub
+    // issues visible to `graph` / `next` / `blocked` — they don't need a
+    // plan file to show up. Native relationship edges (GitHub's typed
+    // blockedBy / blocking / parent / subIssues) are also merged.
+    let focus = amos::amosrc::read_focus(&scan_root)?;
+    let mut adapter_nodes_by_name: std::collections::HashMap<String, AdapterNode> =
+        std::collections::HashMap::new();
+    let nodes = if let Some(focused) = focus.as_deref() {
+        let adapter_nodes = registry.list_nodes_in_milestone(focused);
+        for an in &adapter_nodes {
+            adapter_nodes_by_name.insert(an.name.clone(), an.clone());
+        }
+        merge_local_and_adapter_nodes(local_nodes, adapter_nodes)
+    } else {
+        local_nodes
+    };
 
     // Build DAG
     let dag = Dag::build(nodes.clone()).context("building DAG")?;
@@ -210,10 +236,10 @@ fn main() -> Result<()> {
             status_file.get(name) == amos::status::Status::Done
         };
 
-        // If a milestone is focused, pull adapter facts so we can scope
-        // results to that milestone. Adapter state (closed/milestone) takes
-        // precedence over .amos-status because the latter can drift.
-        let focus = amos::amosrc::read_focus(&scan_root)?;
+        // `focus` was read once up top (driving the adapter enumeration).
+        // Pull adapter facts for every DAG node so blocker state checks can
+        // consult authoritative adapter state, not just local `.amos-status`.
+        // resolve_batch is a single paginated call for github, so it's cheap.
         let adapter_facts: std::collections::HashMap<String, amos::adapter::ResourceFields> =
             if focus.is_some() {
                 let names: Vec<&str> = dag
@@ -324,94 +350,112 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    // Milestones listing — per-milestone open/closed/ready counts pulled from
-    // the adapter. "Ready" means an open node whose blocked_by set is fully
-    // done (via .amos-status) or closed (via adapter state).
+    // Milestones listing — source of truth is the adapter, not the local DAG.
+    // `open`/`done` come directly from native milestone counts; `ready` is
+    // computed per-milestone by enumerating issues and resolving each
+    // blocker's state.
     if matches!(&cli.command, Some(Command::Milestones)) {
-        let names: Vec<&str> = dag
-            .all_nodes()
-            .iter()
-            .filter(|n| registry.is_resolvable(&n.name))
-            .map(|n| n.name.as_str())
-            .collect();
-        let adapter_facts = registry.resolve_batch(&names).unwrap_or_default();
         let status_file = amos::status::StatusFile::load(&scan_root)?;
         let current_focus = amos::amosrc::read_focus(&scan_root)?;
 
-        let is_closed = |node_name: &str| -> bool {
-            adapter_facts
-                .get(node_name)
-                .and_then(|f| f.facts.get("state"))
-                .map(|s| s.eq_ignore_ascii_case("CLOSED"))
-                .unwrap_or(false)
-        };
-        let is_done_or_closed = |node_name: &str| -> bool {
-            if is_closed(node_name) {
-                return true;
-            }
-            status_file.get(node_name) == amos::status::Status::Done
-        };
+        let mut milestones = registry.list_all_milestones();
+        milestones.sort_by(|a, b| a.title.cmp(&b.title));
 
-        // title -> (open, closed, ready)
-        let mut milestone_counts: std::collections::BTreeMap<String, (usize, usize, usize)> =
+        // For every open milestone, enumerate its nodes (issues + native
+        // relationships) so we can compute `ready`. Collect blocker names
+        // that point outside the milestone — we resolve their state in a
+        // single batch call at the end.
+        let mut by_milestone: std::collections::BTreeMap<String, Vec<AdapterNode>> =
             std::collections::BTreeMap::new();
-        for (node_name, fields) in adapter_facts.iter() {
-            let Some(ms) = fields.facts.get("milestone") else { continue };
-            let state = fields
-                .facts
-                .get("state")
-                .map(|s| s.as_str())
-                .unwrap_or("OPEN");
-            let entry = milestone_counts.entry(ms.clone()).or_default();
-            if state.eq_ignore_ascii_case("CLOSED") {
-                entry.1 += 1;
+        let mut extra_state_lookups: HashSet<String> = HashSet::new();
+        for ms in &milestones {
+            if ms.open_count == 0 {
+                by_milestone.insert(ms.title.clone(), Vec::new());
                 continue;
             }
-            entry.0 += 1;
-            // Ready = all blockers satisfied.
-            let blockers = dag.blocked_by_of(node_name);
-            let all_satisfied = blockers.iter().all(|b| is_done_or_closed(&b.name));
-            if all_satisfied {
-                entry.2 += 1;
+            let nodes = registry.list_nodes_in_milestone(&ms.title);
+            let in_ms: HashSet<String> = nodes.iter().map(|n| n.name.clone()).collect();
+            for n in &nodes {
+                for blocker in &n.blocked_by {
+                    if !in_ms.contains(blocker) {
+                        extra_state_lookups.insert(blocker.clone());
+                    }
+                }
             }
+            by_milestone.insert(ms.title.clone(), nodes);
         }
+
+        let extra_refs: Vec<&str> = extra_state_lookups.iter().map(|s| s.as_str()).collect();
+        let extra_facts = registry.resolve_batch(&extra_refs).unwrap_or_default();
+
+        let is_closed_name = |name: &str, within: &[AdapterNode]| -> bool {
+            if let Some(n) = within.iter().find(|n| n.name == name) {
+                return n
+                    .facts
+                    .get("state")
+                    .map(|s| s.eq_ignore_ascii_case("CLOSED"))
+                    .unwrap_or(false);
+            }
+            if let Some(f) = extra_facts.get(name) {
+                if let Some(state) = f.facts.get("state") {
+                    return state.eq_ignore_ascii_case("CLOSED");
+                }
+            }
+            status_file.get(name) == amos::status::Status::Done
+        };
+
         if cli.json {
-            let milestones_arr: Vec<serde_json::Value> = milestone_counts
+            let arr: Vec<serde_json::Value> = milestones
                 .iter()
-                .map(|(title, (open, closed, ready))| {
+                .map(|ms| {
+                    let nodes = by_milestone
+                        .get(&ms.title)
+                        .cloned()
+                        .unwrap_or_default();
+                    let ready = count_ready_in(&nodes, &|n| is_closed_name(n, &nodes));
                     serde_json::json!({
-                        "title": title,
-                        "open": open,
+                        "title": ms.title,
+                        "state": ms.state,
+                        "open": ms.open_count,
+                        "done": ms.closed_count,
                         "ready": ready,
-                        "done": closed,
-                        "focused": current_focus.as_deref() == Some(title.as_str()),
+                        "focused": current_focus.as_deref() == Some(ms.title.as_str()),
                     })
                 })
                 .collect();
             println!("{}", serde_json::json!({
                 "focus": current_focus,
-                "milestones": milestones_arr,
+                "milestones": arr,
             }));
             return Ok(());
         }
-        if milestone_counts.is_empty() {
-            eprintln!("amos: no milestones found in adapter data");
+
+        if milestones.is_empty() {
+            eprintln!("amos: no milestones found");
             return Ok(());
         }
         println!("{:2}{:50}  {:>6}  {:>6}  {:>6}", "", "milestone", "open", "ready", "done");
-        for (title, (open, closed, ready)) in milestone_counts {
-            let marker = if current_focus.as_deref() == Some(title.as_str()) {
+        for ms in &milestones {
+            let nodes = by_milestone.get(&ms.title).cloned().unwrap_or_default();
+            let ready = count_ready_in(&nodes, &|n| is_closed_name(n, &nodes));
+            let marker = if current_focus.as_deref() == Some(ms.title.as_str()) {
                 "* "
             } else {
                 "  "
             };
-            let label = format!("\"{}\"", title);
+            let label = format!("\"{}\"", ms.title);
             println!(
                 "{}{:50}  {:>6}  {:>6}  {:>6}",
-                marker, label, open, ready, closed
+                marker, label, ms.open_count, ready, ms.closed_count
             );
         }
         return Ok(());
+    }
+
+    // Sync edges — one-time migration from local plan-file edges to native
+    // adapter relationships (GitHub's typed issue dependencies). Idempotent.
+    if let Some(Command::SyncEdges { dry_run }) = &cli.command {
+        return run_sync_edges(&registry, &nodes, *dry_run, cli.json);
     }
 
     // Default: dump the DAG
@@ -479,7 +523,7 @@ fn build_registry(scan_root: &std::path::Path, nodes: &[amos::parser::Node]) -> 
 
     // 1. Built-in adapters (defaults, can be overridden)
     registry.register(Box::new(FileAdapter::new(scan_root)));
-    registry.register(Box::new(GhAdapter::new(None)));
+    registry.register(Box::new(GhAdapter::with_detected_repo(scan_root)));
     registry.register(Box::new(UrlAdapter::new()));
     registry.register(Box::new(FfmpegAdapter::new(scan_root)));
 
@@ -557,8 +601,214 @@ fn print_migration_report(report: &amos::migrate::MigrationReport, dry_run: bool
 fn build_registry_minimal(scan_root: &std::path::Path) -> AdapterRegistry {
     let mut registry = AdapterRegistry::new();
     registry.register(Box::new(FileAdapter::new(scan_root)));
-    registry.register(Box::new(GhAdapter::new(None)));
+    registry.register(Box::new(GhAdapter::with_detected_repo(scan_root)));
     registry.register(Box::new(UrlAdapter::new()));
     registry.register(Box::new(FfmpegAdapter::new(scan_root)));
     registry
+}
+
+/// Merge adapter-sourced nodes with locally-parsed nodes. Local nodes win for
+/// every AI-facing field (body, context, labels, description) — the adapter
+/// just enriches with native edges. Adapter nodes that have no local match
+/// are added as virtual nodes so the DAG can see them.
+fn merge_local_and_adapter_nodes(
+    mut local: Vec<Node>,
+    adapter_nodes: Vec<AdapterNode>,
+) -> Vec<Node> {
+    let local_names: HashSet<String> = local.iter().map(|n| n.name.clone()).collect();
+
+    for an in &adapter_nodes {
+        if let Some(existing) = local.iter_mut().find(|n| n.name == an.name) {
+            for blocker in &an.blocked_by {
+                if !existing.blocked_by.contains(blocker) {
+                    existing.blocked_by.push(blocker.clone());
+                }
+            }
+            for blocked in &an.blocks {
+                if !existing.blocks.contains(blocked) {
+                    existing.blocks.push(blocked.clone());
+                }
+            }
+        }
+    }
+
+    for an in adapter_nodes {
+        if local_names.contains(&an.name) {
+            continue;
+        }
+        local.push(virtual_node_from_adapter(an));
+    }
+
+    local
+}
+
+/// Construct a minimal `Node` from an `AdapterNode` so it can participate in
+/// the DAG without a local plan file. `source_file` is a sentinel path.
+fn virtual_node_from_adapter(an: AdapterNode) -> Node {
+    let labels = an
+        .facts
+        .get("labels")
+        .map(|s| s.split(',').map(|t| t.trim().to_string()).collect())
+        .unwrap_or_default();
+    Node {
+        name: an.name,
+        description: if an.title.is_empty() { None } else { Some(an.title) },
+        blocked_by: an.blocked_by,
+        blocks: an.blocks,
+        related_to: Vec::new(),
+        duplicates: None,
+        superseded_by: None,
+        labels,
+        priority: None,
+        context: Vec::new(),
+        adapters: std::collections::HashMap::new(),
+        source_file: PathBuf::from("<adapter>"),
+        line_number: 0,
+        body: String::new(),
+    }
+}
+
+/// Count adapter nodes that are open AND have zero open blockers.
+fn count_ready_in(
+    nodes: &[AdapterNode],
+    is_closed: &dyn Fn(&str) -> bool,
+) -> usize {
+    nodes
+        .iter()
+        .filter(|n| {
+            let state = n.facts.get("state").map(|s| s.as_str()).unwrap_or("OPEN");
+            if state.eq_ignore_ascii_case("CLOSED") {
+                return false;
+            }
+            n.blocked_by.iter().all(|b| is_closed(b))
+        })
+        .count()
+}
+
+/// Push every local `blocked_by` / `blocks` edge up to the adapter as a
+/// native relationship. Each operation is idempotent — "already exists"
+/// responses are logged as success.
+fn run_sync_edges(
+    registry: &AdapterRegistry,
+    nodes: &[Node],
+    dry_run: bool,
+    as_json: bool,
+) -> Result<()> {
+    // Collect edges as a canonical (blocked, blocker) pair so mirror
+    // declarations (plan A says `blocks: [B]` AND plan B says `blocked_by:
+    // [A]`) deduplicate before we push them to the adapter. We emit every
+    // edge as the BlockedBy variant because that's what the GitHub mutation
+    // takes directly.
+    let mut edge_set: std::collections::BTreeSet<(String, String)> = Default::default();
+    for node in nodes {
+        if !registry.is_resolvable(&node.name) {
+            continue;
+        }
+        for blocker in &node.blocked_by {
+            if registry.is_resolvable(blocker) {
+                edge_set.insert((node.name.clone(), blocker.clone()));
+            }
+        }
+        for blocked in &node.blocks {
+            if registry.is_resolvable(blocked) {
+                edge_set.insert((blocked.clone(), node.name.clone()));
+            }
+        }
+    }
+    let planned: Vec<(String, String, RelationshipKind)> = edge_set
+        .into_iter()
+        .map(|(blocked, blocker)| (blocked, blocker, RelationshipKind::BlockedBy))
+        .collect();
+
+    if planned.is_empty() {
+        if as_json {
+            println!(
+                "{}",
+                serde_json::json!({"planned": 0, "applied": 0, "dry_run": dry_run, "edges": []})
+            );
+        } else {
+            eprintln!("amos: no local edges to sync");
+        }
+        return Ok(());
+    }
+
+    let edges_json: Vec<serde_json::Value> = planned
+        .iter()
+        .map(|(from, to, kind)| {
+            serde_json::json!({
+                "from": from,
+                "to": to,
+                "kind": format!("{:?}", kind),
+            })
+        })
+        .collect();
+
+    let mut applied = 0usize;
+    let mut failed: Vec<(String, String, String)> = Vec::new();
+
+    for (from, to, kind) in &planned {
+        if dry_run {
+            if !as_json {
+                println!("- would sync: {} {:?} {}", from, kind, to);
+            }
+            continue;
+        }
+        match registry.add_relationship(from, to, *kind) {
+            Ok(()) => {
+                applied += 1;
+                if !as_json {
+                    println!("✓ {} {:?} {}", from, kind, to);
+                }
+            }
+            Err(e) => {
+                let msg = format!("{:#}", e);
+                let lower = msg.to_ascii_lowercase();
+                if lower.contains("already") || lower.contains("duplicate") {
+                    applied += 1;
+                    if !as_json {
+                        println!("• {} {:?} {} (already exists)", from, kind, to);
+                    }
+                } else {
+                    failed.push((from.clone(), to.clone(), msg.clone()));
+                    if !as_json {
+                        eprintln!("✗ {} {:?} {}: {}", from, kind, to, msg);
+                    }
+                }
+            }
+        }
+    }
+
+    if as_json {
+        let failures: Vec<serde_json::Value> = failed
+            .iter()
+            .map(|(from, to, err)| serde_json::json!({"from": from, "to": to, "error": err}))
+            .collect();
+        println!(
+            "{}",
+            serde_json::json!({
+                "planned": planned.len(),
+                "applied": applied,
+                "failed": failures.len(),
+                "failures": failures,
+                "dry_run": dry_run,
+                "edges": edges_json,
+            })
+        );
+    } else {
+        eprintln!(
+            "amos: {}/{} edges synced{}",
+            applied,
+            planned.len(),
+            if !failed.is_empty() {
+                format!(", {} failed", failed.len())
+            } else {
+                String::new()
+            }
+        );
+    }
+
+    if !failed.is_empty() && !dry_run {
+        bail!("{} relationship sync operation(s) failed", failed.len());
+    }
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use std::collections::HashSet;
 use std::path::PathBuf;
 
-use amos::adapter::{AdapterNode, AdapterRegistry, RelationshipKind};
+use amos::adapter::{AdapterNode, AdapterRegistry, IssueSpec, RelationshipKind};
 use amos::adapter_pull;
 use amos::cli::{Cli, Command};
 use amos::dag::Dag;
@@ -110,6 +110,14 @@ fn main() -> Result<()> {
             return Ok(());
         }
         _ => {}
+    }
+
+    // Issue create talks to the adapter only — no local scan required. Route
+    // it early so projects with legacy plan-file formats can still file new
+    // issues without having to migrate first.
+    if let Some(Command::IssueCreate { scheme, spec }) = &cli.command {
+        let registry = build_registry(&scan_root, &[]);
+        return run_issue_create(&registry, scheme, spec, cli.json);
     }
 
     // Scan + parse. Scanning is optional for commands that only talk to the
@@ -458,6 +466,11 @@ fn main() -> Result<()> {
         return run_sync_edges(&registry, &nodes, *dry_run, cli.json);
     }
 
+    // Issue create — atomic create-with-relationships from a JSON spec.
+    if let Some(Command::IssueCreate { scheme, spec }) = &cli.command {
+        return run_issue_create(&registry, scheme, spec, cli.json);
+    }
+
     // Default: dump the DAG
     eprintln!("amos: {} nodes", dag.all_nodes().len());
     print!("{}", output::format_dag(&dag, &registry));
@@ -683,6 +696,129 @@ fn count_ready_in(
             n.blocked_by.iter().all(|b| is_closed(b))
         })
         .count()
+}
+
+/// Create a new issue from a JSON spec, then atomically apply native
+/// relationship edges. Returns the URL + canonical amos name so a calling
+/// skill can reference the newly-created issue immediately.
+fn run_issue_create(
+    registry: &AdapterRegistry,
+    scheme: &str,
+    spec_path: &str,
+    as_json: bool,
+) -> Result<()> {
+    let raw = if spec_path == "-" {
+        let mut buf = String::new();
+        use std::io::Read;
+        std::io::stdin()
+            .read_to_string(&mut buf)
+            .context("reading spec from stdin")?;
+        buf
+    } else {
+        std::fs::read_to_string(spec_path)
+            .with_context(|| format!("reading spec from {}", spec_path))?
+    };
+
+    let parsed: serde_json::Value = serde_json::from_str(&raw)
+        .context("parsing issue spec JSON")?;
+
+    let spec = IssueSpec {
+        title: parsed
+            .get("title")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        body: parsed
+            .get("body")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string(),
+        milestone: parsed
+            .get("milestone")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        labels: json_string_array(&parsed, "labels"),
+        blocked_by: json_string_array(&parsed, "blocked_by"),
+        blocks: json_string_array(&parsed, "blocks"),
+        sub_issue_of: parsed
+            .get("sub_issue_of")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+    };
+
+    let created = registry
+        .create_issue(scheme, &spec)
+        .context("creating issue")?;
+
+    // Apply relationships. Failures don't undo the issue creation (the
+    // issue is already there); we report them in the result so the caller
+    // can decide whether to retry.
+    let mut relationship_failures: Vec<(String, String, String)> = Vec::new();
+    for blocker in &spec.blocked_by {
+        if let Err(e) = registry.add_relationship(&created.name, blocker, RelationshipKind::BlockedBy) {
+            relationship_failures.push((
+                created.name.clone(),
+                blocker.clone(),
+                format!("{:#}", e),
+            ));
+        }
+    }
+    for blocked in &spec.blocks {
+        if let Err(e) = registry.add_relationship(&created.name, blocked, RelationshipKind::Blocks) {
+            relationship_failures.push((
+                created.name.clone(),
+                blocked.clone(),
+                format!("{:#}", e),
+            ));
+        }
+    }
+    if let Some(parent) = &spec.sub_issue_of {
+        if let Err(e) = registry.add_relationship(&created.name, parent, RelationshipKind::SubIssueOf) {
+            relationship_failures.push((
+                created.name.clone(),
+                parent.clone(),
+                format!("{:#}", e),
+            ));
+        }
+    }
+
+    if as_json {
+        let failures_json: Vec<serde_json::Value> = relationship_failures
+            .iter()
+            .map(|(f, t, e)| serde_json::json!({"from": f, "to": t, "error": e}))
+            .collect();
+        println!(
+            "{}",
+            serde_json::json!({
+                "ok": true,
+                "name": created.name,
+                "number": created.number,
+                "url": created.url,
+                "relationship_failures": failures_json,
+            })
+        );
+    } else {
+        println!("amos: created {} — {}", created.name, created.url);
+        if !relationship_failures.is_empty() {
+            eprintln!("amos: {} relationship(s) failed to apply:", relationship_failures.len());
+            for (f, t, e) in &relationship_failures {
+                eprintln!("  {} → {}: {}", f, t, e);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn json_string_array(value: &serde_json::Value, key: &str) -> Vec<String> {
+    value
+        .get(key)
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// Push every local `blocked_by` / `blocks` edge up to the adapter as a

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,18 +120,22 @@ fn main() -> Result<()> {
         return run_issue_create(&registry, scheme, spec, cli.json);
     }
 
-    // Scan + parse. Scanning is optional for commands that only talk to the
-    // adapter — SyncEdges and Milestones (adapter-first) work without local
-    // nodes, but we still scan so status/focus helpers have a consistent
-    // scan_root to anchor on.
+    // Scan + parse. With adapter-first enumeration, most queries (graph,
+    // next, blocked, orphans, milestones) pull their node set from the
+    // adapter when a milestone is focused — a project can be fully
+    // remote-first with zero local plan files and still be usable.
     let blocks = scanner::scan_directory(&scan_root)
         .with_context(|| format!("scanning {}", scan_root.display()))?;
 
-    let can_run_without_local_nodes = matches!(
+    // Only commands that operate purely on local files (`validate`, the DAG
+    // dump that runs by default) require at least one local block. Every
+    // other command either reads from the adapter or reshapes state that
+    // exists independently of plan files.
+    let requires_local_blocks = matches!(
         &cli.command,
-        Some(Command::Milestones) | Some(Command::SyncEdges { .. })
+        Some(Command::Validate) | None
     );
-    if blocks.is_empty() && !can_run_without_local_nodes {
+    if blocks.is_empty() && requires_local_blocks {
         eprintln!("No amos blocks found in {}", scan_root.display());
         std::process::exit(1);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -742,6 +742,10 @@ fn run_issue_create(
             .and_then(|v| v.as_str())
             .map(String::from),
         labels: json_string_array(&parsed, "labels"),
+        issue_type: parsed
+            .get("issue_type")
+            .and_then(|v| v.as_str())
+            .map(String::from),
         blocked_by: json_string_array(&parsed, "blocked_by"),
         blocks: json_string_array(&parsed, "blocks"),
         sub_issue_of: parsed


### PR DESCRIPTION
## Summary

Two related workflow fixes for amos projects:

1. **Adapter-first enumeration** — GitHub issues without a local plan file were previously invisible to `amos milestones` / `next` / `blocked` / `graph`. Every command now enumerates from the adapter (GitHub), and plan files become optional AI-notes overlays.
2. **Consistent issue filing** — new `amos-file` skill + `amos issue-create` subcommand. From short natural-language intent, drafts a well-shaped issue following the project's template (`docs/issue-template.md` or `.github/ISSUE_TEMPLATE/*.md`), infers milestone and labels with an `AskUserQuestion` fallback when confidence is low, extracts explicit relationships, and creates the issue atomically with native `blockedBy` / `blocking` / `parent` edges applied.

Also included:

- `amos sync-edges` — one-time migration that pushes existing plan-file `blocked_by:` / `blocks:` frontmatter up to native GitHub relationships. Idempotent; safe to re-run.
- `amos-next` Step 7 now detects every issue the branch addresses (primary + commit-message `Closes #N` + branch name) so merges auto-close the full set, not just the primary issue.
- Adapter trait extensions: `list_milestones`, `list_nodes_in_milestone`, `add_relationship`, `create_issue` (default no-op/error impls — non-GitHub adapters are untouched and forward-compatible).
- `GhAdapter::with_detected_repo` — auto-detects `owner/name` from the scan root's git remote.

## Motivation

Pre-change behavior required a local `plan/N-slug.md` for every issue you wanted amos to see. Two-source-of-truth trap: file an issue in GitHub, it doesn't show up in `amos next`, no warning. Concretely observed on streamlib: 6 open issues in the focused milestone reported `open: 0`, hiding the next unit of work.

Filing issues also required hand-authoring the full template every time. That's friction we can remove — the template rarely changes, milestone inference is usually obvious, and the rare ambiguous cases are exactly when `AskUserQuestion` shines. The skill drafts; the user approves the whole package in one step; the binary creates the issue + applies labels/milestone/relationships atomically.

## Design

- **Trait extension (back-compat)**: four new `Adapter` methods with empty default impls — `list_milestones`, `list_nodes_in_milestone`, `add_relationship`, `create_issue`. Non-GitHub adapters are untouched.
- **GhAdapter**: implements all four via `gh api graphql` / `gh issue create`. Detects `owner/name` from the scan root's git remote so no new configuration is required.
- **main.rs** merges adapter-sourced nodes with parsed local nodes: local wins for AI-facing fields (body, context, labels); the adapter provides state + native edges and contributes virtual nodes for issues that have no local plan.
- **sync-edges**: iterates every resolvable local edge, normalizes to a canonical `(blocked, blocker)` form (so mirror declarations don't push twice), and calls `addBlockedBy`. "Already exists" responses are treated as success, making the operation idempotent.
- **issue-create**: the `amos-file` skill produces a JSON `IssueSpec` (title, body, milestone, labels, blocked_by, blocks, sub_issue_of) and pipes it to the binary. Binary does `gh issue create` then applies native relationships in a single pass. Partial relationship failures are reported to stderr; the issue exists either way.
- **PR auto-link** — pure skill change in `amos-next`. Grep the branch's commits for `Closes / Fixes / Resolves #N`, combine with the primary issue and branch-name detection, emit one `Closes #N` per line in the PR body.

## Test plan

- [x] `cargo test` — 68 passed (11 new: remote URL parsing, adapter-node JSON mapping, trait-default fallbacks, registry routing, empty-title rejection).
- [x] `cargo clippy` — no new warnings introduced by this PR.
- [x] Live smoke against tatolab/streamlib:
  - [x] `amos milestones` shows accurate counts (Polyglot SDK Realignment fixed: 6 open / 3 done, matching GitHub).
  - [x] `amos next` in the focused milestone enumerates the 6 unplanned issues that were previously invisible.
  - [x] `amos sync-edges --dry-run` reports 123 unique edges (140 raw, 17 mirror dedups).
  - [x] `amos sync-edges` applied all 123; zero failures.
  - [x] Post-migration verification queried GitHub `blockedBy` for every source issue and diffed against the snapshot — zero missing / zero extra.
- [x] `amos issue-create` subcommand: edge cases (empty title, malformed JSON, missing scheme) route cleanly.

## Breaking changes

None. Existing plan-file edges are still read and merged. Projects that haven't migrated keep working.

## Follow-ups (not in this PR)

- After downstream projects run `sync-edges` and verify, delete the plan-file DAG code path.
- Add batch node-ID lookup to `add_relationship` (currently ~2 GraphQL calls per edge — acceptable at this scale).
- Sub-issue (parent/child) support in `amos-file` once any project uses GitHub's sub-issue feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)