### PR TITLE
docs(skills): add staleness check + low-resolution issue template

### DIFF
--- a/.claude/skills/amos-file/SKILL.md
+++ b/.claude/skills/amos-file/SKILL.md
@@ -67,45 +67,78 @@ Look, in order:
 
 Read the file. Follow its section headers verbatim. Don't invent new sections.
 
-### Amos default template
+### Amos default template — keep it low-resolution
+
+Issues capture **goals**, not pre-implementation plans. The picker
+will research current state at pickup time and produce the
+high-resolution plan; specifics in the issue body just create
+staleness for the next agent to clean up. Resist the urge to be
+exhaustive. Phrase claims about specific code or behavior as "to
+the best of our current knowledge" so the picker knows to verify.
 
 ```markdown
 ## Description
-One short paragraph, written for an AI agent with no prior context.
+One short paragraph stating the goal — *what* this issue delivers
+and roughly *how* done looks. Written for a future agent picking
+this up cold. No file paths, no implementation ordering, no
+ruled-out approaches.
 
 ## Context
-Why this matters. Constraints, prior work, related discussion.
+Why this matters and what constraints bound the work. Phrase
+specific code/behavior claims as "to the best of our current
+knowledge" — the picker is required to verify against current
+state, not trust the body verbatim.
 
 ## Exit criteria
-- [ ] <concrete deliverable>
-- [ ] <concrete deliverable>
+2–4 high-level deliverables that define "done." The picker
+expands them into a detailed plan.
+
+- [ ] <high-level deliverable>
+- [ ] <high-level deliverable>
 
 ## Tests / validation
-- [ ] <inline test case>  OR  "Blocked by #N (test harness)"
+The *shape* of validation needed, not exact test names.
+
+- [ ] Unit test(s) covering <what behavior>
+- [ ] E2E scenario: <one-line description>
+
+OR — "Blocked by #N (test harness)"
 
 ## Related
 - Milestone: <name>
-- See also: #N, #M
+- See also: #N (free-text only — dependency edges go through native
+  GitHub relationships)
 
 <!-- amos:ai-notes-begin -->
 ## AI Agent Notes
 
-Agent-facing context that doesn't belong in the human-readable sections
-above. Include only what's useful to a future agent walking in cold:
+None.
 
-- Exact error strings, VUIDs, stack traces from the conversation that
-  led to this issue (search-fuel for lookups).
-- Concrete file paths + line numbers relevant to the fix.
-- Approaches already tried or ruled out, with the reason.
-- Hidden constraints or invariants the code enforces.
-- Pointers to adjacent amos nodes or docs (`@github:owner/repo#N`,
-  `docs/learnings/foo.md`).
-
-Skip anything already obvious from the Description or Exit criteria —
-no duplication. If there's nothing agent-specific to add, leave an
-explicit "None." so a future reader knows it wasn't forgotten.
 <!-- amos:ai-notes-end -->
 ```
+
+**Default the AI Agent Notes section to "None."** It exists for
+things a future picker genuinely cannot derive from current code —
+a hidden invariant, a ruled-out approach with reasoning, a
+non-obvious gotcha. If you're tempted to fill it with file paths,
+ordering suggestions, or "implementation hints," **don't** —
+those go stale fast and burden the picker with corrections.
+
+Examples of content that *does* belong in AI Agent Notes:
+
+- An exact error string / VUID / stack trace from a debugging
+  conversation (search-fuel that survives refactors).
+- A ruled-out approach with the *reason* it was ruled out (so the
+  picker doesn't redo the dead-end).
+- A hidden invariant the code enforces but doesn't document.
+
+Examples of content that does *not* belong (will go stale):
+
+- "File this PR sequentially after #X."
+- "Suggested order: A, B, C."
+- "Edit `foo/bar.rs` line 137."
+- "Check that VulkanReadView still impls CpuReadable."
+- A summary of an investigation the picker could redo themselves.
 
 **Do NOT** put `Blocked by:` / `Blocks:` in the `Related` section — those are
 set via native GitHub relationships, not text. The `Related` section is for

--- a/.claude/skills/amos-next/SKILL.md
+++ b/.claude/skills/amos-next/SKILL.md
@@ -93,9 +93,55 @@ read every matching file into context. Those specialty workflows carry
 mandatory rules for the kind of work (`ci`, `video-e2e`, `macos`,
 `polyglot`, `research`, etc.).
 
+## Step 2.5 — Verify against current state (staleness check)
+
+**Issues are goals, not specs.** The body — exit criteria, suggested
+file paths, AI Agent Notes, ruled-out approaches, related-issue
+references — captures the best understanding when the issue was
+filed. Code lands, dependencies close, architectures shift; by the
+time you pick the issue up, parts of the body may be stale.
+
+Before announcing a plan, audit the issue body against current code
+and current issue state. For each load-bearing claim in the body,
+check:
+
+- **Referenced files / code paths** still exist in the shape claimed.
+  If the body says "edit X in module Y," confirm Y still exists and
+  X is still where it says.
+- **Cited "defects" or "missing features"** are still real. PRs that
+  landed since filing may have already addressed them.
+- **Suggested follow-up issues** haven't already been filed. If the
+  body says "file three implementation issues," check whether
+  `gh issue list` already shows them — they may exist with
+  `blocked_by: #<this>`.
+- **Dependency edges** match GitHub. If the body claims a `Blocked
+  by` relationship, confirm it via `amos show`.
+- **AI Agent Notes** still reflect reality. Strike-out items that
+  are no longer true (per the markdown-editing rules in CLAUDE.md —
+  preserve disagreement, don't silently overwrite).
+
+Use the Agent tool with `subagent_type=Explore` for non-trivial
+verification across multiple files; for narrow lookups, Grep / Read /
+`gh issue view` directly.
+
+If you find staleness, update the issue body in place via
+`gh issue edit <N> --body-file ...` with strike-throughs and reasoning
+preserved. Do this *before* announcing the plan, so the announcement
+references a clean issue body and a future picker doesn't have to
+re-derive the same dead ends.
+
+The plan you announce in Step 3 is the **fresh plan**, not a
+regurgitation of the issue body. Where the body and current evidence
+disagree, the plan goes with current evidence (and explicitly notes
+what changed and why).
+
 ## Step 3 — Announce + gate on confirmation
 
-Compose a short announcement in English (not JSON). Example shape:
+Compose a short announcement in English (not JSON). The plan you
+announce is the *fresh* plan from Step 2.5 — exit criteria, files in
+scope, and tests are what *current state* dictates, not what the
+issue body literally says (where the two diverge, lead with the
+fresh plan and call out the divergence). Example shape:
 
 ```
 ## Starting Task
@@ -105,10 +151,13 @@ Compose a short announcement in English (not JSON). Example shape:
 - **Labels**: <labels, or "none">
 - **Loaded workflows**: <files read, or "none">
 - **Branch**: `<branch-name>`
-- **Summary**: <1–2 sentence plan from the Description section>
-- **Exit criteria**: <N items from the Exit criteria section>
-- **Test gate**: <list of tests to run from the Tests/validation section>
-- **Files in scope**: <from issue + workflows>
+- **Goal** (paraphrased from issue): <1–2 sentences>
+- **Refined plan** (after Step 2.5 staleness check):
+  - Exit criteria: <fresh, current-state-aware deliverables>
+  - Files in scope: <from current code, not just issue body>
+  - Test shape: <from issue + workflows, refined for current state>
+- **What changed vs. issue body**: <list of items struck out,
+  references that have moved, or "no divergence">
 - **Scope estimate**: small | medium | large
 
 Proceed? [y/n]
@@ -128,8 +177,10 @@ from the conventional-commit family.
 
 ## Step 5 — Do the work
 
-- Scope: strictly the Exit criteria. Note anything else as follow-up,
-  don't touch.
+- Scope: the **goal as refined in Step 3's plan**, not a literal
+  reading of every checkbox in the issue body. If the body says
+  "do X, Y, Z" and Step 2.5 found Y is already done, skip Y.
+- Note anything genuinely out of scope as a follow-up, don't touch.
 - Honor `CLAUDE.md` + every loaded workflow file.
 - `cargo check` (or project equivalent) frequently.
 - Conventional commits. Never commit broken code.
@@ -154,7 +205,27 @@ Don't push until the gate is green. If a listed test can't run in this
 environment (no GPU CI, etc.), mark ⏭ skipped with a clear reason and
 note that CI must catch it.
 
-## Step 7 — Push + open PR
+## Step 7 — Pre-PR review gate (automatic)
+
+**Do not ask the user "open PR? [y/n]".** Invoke the `pr-review-gate`
+skill with the branch's diff and the issue context; use its verdict to
+decide what happens next:
+
+- **PASS** — proceed straight to Step 8 (push + open PR). Print one
+  line like "Review passed — opening PR."
+- **FIX** — apply the listed fixes on this branch, re-run the test
+  gate (Step 6), commit with message `review: address pr-review-gate
+  feedback`, and re-invoke `pr-review-gate`. Cap the loop at 3
+  iterations; on the 4th, treat as DISCUSS.
+- **DISCUSS** — surface the reviewer's rationale verbatim and ask the
+  user: "Want me to fix these or open the PR anyway?" Do not proceed
+  without an explicit answer.
+
+The gate is intentionally narrow — it only decides whether to open the
+PR. Merge decisions, follow-up filing, and broader discussion stay
+with the user at Step 9.
+
+## Step 8 — Push + open PR
 
 Before creating the PR, collect **every** issue the branch addresses — not just
 the primary one from Step 1 — so GitHub auto-closes all of them on merge.
@@ -209,7 +280,7 @@ EOF
 One `Closes #N` per line — GitHub's auto-close parser only fires on that
 exact shape. `Closes #1, #2, #3` on one line does NOT work.
 
-## Step 8 — Report back
+## Step 9 — Report back
 
 English summary, not JSON:
 


### PR DESCRIPTION
## Summary

- **`amos-next`**: new Step 2.5 "Verify against current state (staleness check)" — picker audits the issue body against current code + current issue state before announcing a plan, updates the body in place with strike-throughs when load-bearing claims have gone stale, and announces a fresh plan that supersedes the body where evidence has shifted. Step 3 announcement, Step 5 scope, and Step 7 pre-PR review gate updated to match.
- **`amos-file`**: default template rewritten to be low-resolution. Issues capture goals, not pre-implementation plans; the picker produces the high-resolution plan at pickup time. AI Agent Notes default to "None." with explicit examples of what does and does not belong (search-fuel + ruled-out approaches with reasoning belong; ordering suggestions and file paths don't).

## Why

streamlib issue #528 surfaced repeated staleness in issue bodies — impl issues already filed, dependency edges already wired, "defects" already fixed at compile time. The pickup-research loop catches that automatically, and the lower-resolution template prevents new issues from being filed with the same staleness problem baked in. See tatolab/streamlib#540 for the matching streamlib-side changes (CLAUDE.md "Editing markdown documentation" rules, "Issues are goals, not specs" reframing in Work Tracking, lower-resolution `docs/issue-template.md`).

## Test plan

- [x] Both files were already in active use locally for the streamlib #528 work — the staleness check ran successfully (caught three stale AI Agent Notes in the original issue body).
- [x] No code in this PR — pure skill-doc updates.

## Follow-ups

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)